### PR TITLE
fix copilot workflow to use official action (fixes #223)

### DIFF
--- a/.github/workflows/copilot-pr-review.yml
+++ b/.github/workflows/copilot-pr-review.yml
@@ -10,41 +10,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
       
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         
-      - name: Request Copilot Review
-        uses: actions/github-script@v6
+      - name: Copilot Review
+        uses: github/copilot-pr-summary@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              // Request Copilot as a reviewer for the PR
-              await github.rest.pulls.requestReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-                reviewers: ['copilot']
-              });
-              
-              // Add a comment to indicate copilot reviewer was assigned
-              await github.rest.issues.createComment({
-                issue_number: context.payload.pull_request.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: '🤖 Copilot has been assigned as a reviewer for this pull request.'
-              });
-            } catch (error) {
-              console.log('Error requesting Copilot as reviewer:', error.message);
-              
-              // Fallback: Add a comment indicating the review was triggered
-              await github.rest.issues.createComment({
-                issue_number: context.payload.pull_request.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: '🤖 Copilot PR review has been triggered for this pull request. (Note: Could not assign as reviewer - user may need to be added manually)'
-              });
-            }
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace manual reviewer assignment with `github/copilot-pr-summary@v1` action
- Remove unnecessary permissions and error handling code
- Fix automatic Copilot PR reviews functionality

## Test plan
- [ ] Create a test PR to verify Copilot review is triggered automatically
- [ ] Confirm workflow runs without errors

Fixes #223

🤖 Generated with [Claude Code](https://claude.ai/code)