### PR TITLE
Fix section heading visibility in 2025.html

### DIFF
--- a/static/2025.html
+++ b/static/2025.html
@@ -473,7 +473,7 @@
         </div>
       </div>
 
-      <h2 class="mt-4">部門について</h2>
+      <h2 class="mt-4 text-dark">部門について</h2>
       <div class="text-start">
         <div class="row">
           <div class="col-md-6 mb-4">


### PR DESCRIPTION
## Summary
• Fixed visibility issue with "部門について" (section about divisions) heading in 2025.html
• Added `text-dark` class to ensure proper contrast against blue background

## Test plan
- [x] Verify heading is now visible against the blue background section
- [x] Check that text contrast meets accessibility standards

🤖 Generated with [Claude Code](https://claude.ai/code)