### PR TITLE
Fix text-dark CSS specificity issue in heading elements

### DIFF
--- a/static/2025.html
+++ b/static/2025.html
@@ -89,6 +89,15 @@
       margin-bottom: 1.5rem;
       color: var(--primary);
     }
+    
+    /* text-darkクラスが指定された見出しの色を修正 */
+    h1.text-dark,
+    h2.text-dark,
+    h3.text-dark,
+    h4.text-dark,
+    h5.text-dark {
+      color: #333 !important;
+    }
 
     h1 {
       font-size: 2.5rem;


### PR DESCRIPTION
## Summary
- Fixed CSS specificity issue where `text-dark` class was not applying to heading elements (h1-h5)
- Added higher specificity CSS rules to ensure `text-dark` class overrides default heading colors
- Used `\!important` to guarantee proper color application

## Test plan
- [ ] Verify that `text-dark` class now properly applies dark text color to heading elements
- [ ] Check that existing heading styles remain unaffected when `text-dark` is not applied
- [ ] Test visual appearance on the 2025.html page

🤖 Generated with [Claude Code](https://claude.ai/code)