### PR TITLE
feat: 次回イベントの表示を強調

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -10,6 +10,7 @@
     integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
   <link rel="stylesheet" href="styles_white.css">
   <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
     crossorigin="anonymous"></script>
@@ -318,6 +319,33 @@
         padding: 3rem 0;
       }
     }
+
+    /* アニメーション定義を追加 */
+    @keyframes pulse {
+      0% {
+        transform: scale(1);
+        box-shadow: 0 4px 15px rgba(255, 193, 7, 0.3);
+      }
+      50% {
+        transform: scale(1.02);
+        box-shadow: 0 6px 20px rgba(255, 193, 7, 0.4);
+      }
+      100% {
+        transform: scale(1);
+        box-shadow: 0 4px 15px rgba(255, 193, 7, 0.3);
+      }
+    }
+
+    /* カードのホバーエフェクトを追加 */
+    .card:hover .date-display span {
+      transform: scale(1.05);
+    }
+
+    .card:hover .btn-outline-light {
+      background-color: rgba(255, 255, 255, 0.1);
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
   </style>
 </head>
 
@@ -326,11 +354,72 @@
   <section class="jumbotron jumbotron-fluid header-section text-center">
     <div class="container">
       <br />
+      <p class="lead mb-2">オンラインブルーグラスフェスティバル</p>
       <h1>
         <span>Bluegrass Lockdown</span> <span>Music Festival</span>
       </h1>
-      <p class="lead mt-3">オンラインブルーグラスフェスティバル</p>
       <br />
+      
+      <!-- 次回開催カード -->
+      <div class="card bg-royalblue text-white mx-auto shadow-lg" style="max-width: 900px; background-color: rgba(108, 138, 183, 0.95);">
+        <div class="card-body p-4">
+          <div class="row g-4">
+            <!-- 左側：イベント情報 -->
+            <div class="col-md-8">
+              <div class="d-flex align-items-center justify-content-center mb-1">
+                <span class="badge" style="
+                  background: linear-gradient(45deg, #ffc107, #ff9800);
+                  color: #fff;
+                  padding: 0.5rem 1rem;
+                  border-radius: 8px;
+                  box-shadow: 0 4px 15px rgba(255, 193, 7, 0.3);
+                  display: inline-block;
+                  transform: translateY(0);
+                  transition: all 0.3s ease;
+                  animation: pulse 2s infinite;
+                  font-size: 1rem;
+                  font-weight: bold;
+                ">NEXT</span>
+                <div class="card-title h3 mb-0 ms-3">BLMF Vol.6</div>
+              </div>
+              <div class="mb-3">
+                <div class="d-flex flex-column align-items-center">
+                  <div class="date-display" style="
+                    padding: 0.8rem 1.5rem 0.4rem;
+                    margin-bottom: -0.3rem;
+                    text-align: center;
+                    transition: transform 0.3s ease;
+                  ">
+                    <span class="fw-bold" style="
+                      font-size: 2rem;
+                      background: linear-gradient(45deg, #ffc107, #ff9800);
+                      -webkit-background-clip: text;
+                      -webkit-text-fill-color: transparent;
+                      text-shadow: 0 2px 4px rgba(0,0,0,0.1);
+                      display: inline-block;
+                      transition: transform 0.3s ease;
+                    ">2025.06.22</span>
+                  </div>
+                  <span class="fw-bold" style="font-size: 1.3rem; margin-top: -0.4rem;">
+                    19時開始 <span style="font-size: 1rem;">(JST)</span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <!-- 右側：アクションボタン -->
+            <div class="col-md-4 d-flex align-items-center justify-content-end">
+              <a href="2025.html" class="btn btn-outline-light btn-lg px-4 w-100" style="
+                transition: all 0.3s ease;
+                border-width: 2px;
+                position: relative;
+                overflow: hidden;
+              ">
+                <i class="bi bi-arrow-right-circle me-2"></i>詳細を見る
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -460,22 +549,12 @@
     </div>
   </section>
 
-
-  <!-- イベント一覧セクション -->
-  <section id="events" class="jumbotron jumbotron-fluid text-center text-white bg-midnightblue">
+  <!-- 過去のイベントセクション -->
+  <section id="past-events" class="jumbotron jumbotron-fluid text-center text-white bg-midnightblue">
     <div class="container p-2">
-      <h1>イベント一覧</h1>
-      <div class="row row-cols-1 row-cols-md-2 g-4 mt-3">
-        <div class="col">
-          <div class="card bg-royalblue text-white h-100">
-            <div class="card-body">
-              <h5 class="card-title">BLMF Vol.6 (2025)</h5>
-              <p class="card-text">2025年6月22日 19時開始(JST)のBluegrass Lockdown Music Festival Vol.6の詳細ページ</p>
-              <a href="2025.html" class="btn btn-outline-light">詳細を見る</a>
-            </div>
-          </div>
-        </div>
-        <div class="col">
+      <h1>過去のイベント</h1>
+      <div class="row justify-content-center">
+        <div class="col-md-6">
           <div class="card bg-royalblue text-white h-100">
             <div class="card-body">
               <h5 class="card-title">BLMF Vol.4 (2024)</h5>


### PR DESCRIPTION
- ヘッダーに次回イベント（BLMF Vol.6）のカードを追加
- それに伴いイベントセクションを「過去のイベント」に
fix #216 

<!-- I want to review in Japanese. -->
<!-- for GitHub Copilot review rule -->
[must] → 次回イベントの表示を強調
[imo] → 
[nits] → 
[ask] → 
[fyi] → 
<!-- for GitHub Copilot review rule-->
<!-- I want to review in Japanese. -->