### PR TITLE
fix: ヘッダーとカードの文字色を統一

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -361,59 +361,29 @@
       <br />
       
       <!-- 次回開催カード -->
-      <div class="card bg-royalblue text-white mx-auto shadow-lg" style="max-width: 900px; background-color: rgba(108, 138, 183, 0.95);">
-        <div class="card-body p-4">
+      <div class="card bg-royalblue text-white mx-auto shadow-lg next-event-card">
+        <div class="card-body">
           <div class="row g-4">
             <!-- 左側：イベント情報 -->
             <div class="col-md-8">
               <div class="d-flex align-items-center justify-content-center mb-1">
-                <span class="badge" style="
-                  background: linear-gradient(45deg, #ffc107, #ff9800);
-                  color: #fff;
-                  padding: 0.5rem 1rem;
-                  border-radius: 8px;
-                  box-shadow: 0 4px 15px rgba(255, 193, 7, 0.3);
-                  display: inline-block;
-                  transform: translateY(0);
-                  transition: all 0.3s ease;
-                  animation: pulse 2s infinite;
-                  font-size: 1rem;
-                  font-weight: bold;
-                ">NEXT</span>
+                <span class="badge">NEXT</span>
                 <div class="card-title h3 mb-0 ms-3">BLMF Vol.6</div>
               </div>
               <div class="mb-3">
                 <div class="d-flex flex-column align-items-center">
-                  <div class="date-display" style="
-                    padding: 0.8rem 1.5rem 0.4rem;
-                    margin-bottom: -0.3rem;
-                    text-align: center;
-                    transition: transform 0.3s ease;
-                  ">
-                    <span class="fw-bold" style="
-                      font-size: 2rem;
-                      background: linear-gradient(45deg, #ffc107, #ff9800);
-                      -webkit-background-clip: text;
-                      -webkit-text-fill-color: transparent;
-                      text-shadow: 0 2px 4px rgba(0,0,0,0.1);
-                      display: inline-block;
-                      transition: transform 0.3s ease;
-                    ">2025.06.22</span>
+                  <div class="date-display">
+                    <span class="fw-bold">2025.06.22</span>
                   </div>
-                  <span class="fw-bold" style="font-size: 1.3rem; margin-top: -0.4rem;">
-                    19時開始 <span style="font-size: 1rem;">(JST)</span>
+                  <span class="time-display fw-bold">
+                    19時開始 <span class="timezone">(JST)</span>
                   </span>
                 </div>
               </div>
             </div>
             <!-- 右側：アクションボタン -->
             <div class="col-md-4 d-flex align-items-center justify-content-end">
-              <a href="2025.html" class="btn btn-outline-light btn-lg px-4 w-100" style="
-                transition: all 0.3s ease;
-                border-width: 2px;
-                position: relative;
-                overflow: hidden;
-              ">
+              <a href="2025.html" class="btn btn-outline-light btn-lg px-4 w-100">
                 <i class="bi bi-arrow-right-circle me-2"></i>詳細を見る
               </a>
             </div>

--- a/static/styles_white.css
+++ b/static/styles_white.css
@@ -93,3 +93,77 @@ h2 span {
   color: #fff;
   background-color: #333;
 }
+
+/* ヘッダーセクションのスタイル */
+.header-section {
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  color: var(--white);
+}
+
+.header-section h1,
+.header-section h2,
+.header-section p,
+.header-section span,
+.header-section .lead {
+  color: var(--white) !important;
+}
+
+/* 次回開催カードのスタイル */
+.next-event-card {
+  max-width: 900px;
+  background-color: rgba(108, 138, 183, 0.95);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+.next-event-card .card-body {
+  padding: 1.5rem;
+}
+
+.next-event-card .badge {
+  background: linear-gradient(45deg, #ffc107, #ff9800);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(255, 193, 7, 0.3);
+  display: inline-block;
+  transform: translateY(0);
+  transition: all 0.3s ease;
+  animation: pulse 2s infinite;
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.next-event-card .date-display {
+  padding: 0.8rem 1.5rem 0.4rem;
+  margin-bottom: -0.3rem;
+  text-align: center;
+  transition: transform 0.3s ease;
+}
+
+.next-event-card .date-display span {
+  font-size: 2rem;
+  background: linear-gradient(45deg, #ffc107, #ff9800);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: inline-block;
+  transition: transform 0.3s ease;
+  color: transparent !important;
+}
+
+.next-event-card .time-display {
+  font-size: 1.3rem;
+  margin-top: -0.4rem;
+  color: var(--white) !important;
+}
+
+.next-event-card .time-display .timezone {
+  font-size: 1rem;
+}
+
+.next-event-card .btn-outline-light {
+  transition: all 0.3s ease;
+  border-width: 2px;
+  position: relative;
+  overflow: hidden;
+}


### PR DESCRIPTION
- headerとcardの強調しない文字を白色に統一
- それに伴いインラインスタイルをstyles_white.cssに移動

fix #232 

<!-- I want to review in Japanese. -->
<!-- for GitHub Copilot review rule -->
[must]  
- headerとcardの強調しない文字を白色に統一
- それに伴いインラインスタイルをstyles_white.cssに移動
<!-- for GitHub Copilot review rule-->
<!-- I want to review in Japanese. -->