### PR TITLE
fix: オンライン・ブルーグラス・アワードとショート・ブルーグラス・アワードの文字色を背景色と別の色に

### DIFF
--- a/static/2025.html
+++ b/static/2025.html
@@ -488,7 +488,7 @@
           <div class="col-md-6 mb-4">
             <div class="card h-100">
               <div class="card-header">
-                <h4 class="mb-0" text-dark>オンライン・ブルーグラス・アワード</h4>
+                <h4 class="mb-0 text-dark">オンライン・ブルーグラス・アワード</h4>
               </div>
               <div class="card-body">
                 <p>フェス出演動画、ライブ動画、本フェス用に作った創作動画を募集します。</p>
@@ -512,7 +512,7 @@
           <div class="col-md-6 mb-4">
             <div class="card h-100">
               <div class="card-header">
-                <h4 class="mb-0" text-dark>ショート・ブルーグラス・アワード</h4>
+                <h4 class="mb-0 text-dark">ショート・ブルーグラス・アワード</h4>
               </div>
               <div class="card-body">
                 <p>3分以内の動画を募集します。</p>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
<!-- for GitHub Copilot review rule -->
[must]  
「オンライン・ブルーグラス・アワード」と「ショート・ブルーグラス・アワード」の文字色が背景色と同じで見えなかったので修正した
<!-- for GitHub Copilot review rule-->
<!-- I want to review in Japanese. -->