### PR TITLE
[Epic2] Cloudflare Workers Static Assetsへのデプロイ設定と本番切替

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,31 +5,30 @@ on:
       - main
 
 jobs:
-  firebase-deploy:
+  cloudflare-deploy:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}'
-
-      - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: bluemoon-82c0b
-   
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '22.x'
+          cache: npm
 
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Deploy to Firebase Hosting
-        run: firebase deploy --only hosting --project bluemoon-82c0b
+      - name: Check
+        run: npm run check
 
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,4 +31,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          wranglerVersion: '4.119.0'
           command: deploy

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -40,6 +40,7 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          wranglerVersion: '4.119.0'
           command: deploy --name bluemoon-pr-${{ github.event.pull_request.number }}
 
       - name: Comment preview URL on PR
@@ -101,4 +102,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          wranglerVersion: '4.119.0'
           command: delete bluemoon-pr-${{ github.event.pull_request.number }} --force

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -2,16 +2,7 @@ name: PR build check & preview
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'src/**'
-      - 'public/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'astro.config.mjs'
-      - 'tsconfig.json'
-      - 'firebase.preview.json'
-      - '.github/workflows/pr-preview.yml'
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number }}
@@ -19,6 +10,7 @@ concurrency:
 
 jobs:
   build-and-preview:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,56 +24,42 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          cache: 'npm'
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Check (astro check)
+      - name: Check
         run: npm run check
 
       - name: Build
         run: npm run build
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}'
-
-      - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: bluemoon-82c0b
-
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools
-
-      - name: Deploy preview channel
+      - name: Deploy preview Worker
         id: deploy
-        run: |
-          firebase hosting:channel:deploy "pr-${{ github.event.pull_request.number }}" \
-            --config firebase.preview.json \
-            --project bluemoon-82c0b \
-            --expires 7d \
-            --json > preview-output.json
-          cat preview-output.json
-          node -e "
-            const fs = require('fs');
-            const out = JSON.parse(fs.readFileSync('preview-output.json', 'utf8'));
-            const sites = out.result?.['bluemoon-82c0b'] ?? Object.values(out.result ?? {})[0] ?? {};
-            const url = sites.url ?? '';
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, \`url=\${url}\n\`);
-          "
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: deploy --name bluemoon-pr-${{ github.event.pull_request.number }}
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.deployment-url }}
+          WORKER_NAME: bluemoon-pr-${{ github.event.pull_request.number }}
         with:
           script: |
-            const url = `${{ steps.deploy.outputs.url }}`;
+            const url = process.env.PREVIEW_URL;
+            if (!url) {
+              core.setFailed('Wrangler did not return a workers.dev deployment URL');
+              return;
+            }
+
             const marker = '<!-- pr-preview-comment -->';
             const body = [
               marker,
-              `🔍 プレビューをデプロイしました: ${url}`,
+              `🔍 Cloudflare Workers preview: ${url}`,
+              `Worker: ${process.env.WORKER_NAME}`,
               '',
               '(このコメントは新しいpushのたびに更新されます)',
             ].join('\n');
@@ -91,7 +69,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            const existing = comments.find((c) => c.body?.includes(marker));
+            const existing = comments.find((comment) => comment.body?.includes(marker));
 
             if (existing) {
               await github.rest.issues.updateComment({
@@ -108,3 +86,19 @@ jobs:
                 body,
               });
             }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Delete preview Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: delete bluemoon-pr-${{ github.event.pull_request.number }} --force

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ sw.*
 # Astro
 .astro/
 dist/
+
+# Cloudflare Wrangler
+.wrangler/
+.dev.vars

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ src/
 └── styles/global.css
 
 public/          # そのまま配信される静的ファイル(favicon等)
-static/          # 現行の本番サイト(Firebase Hosting配信元、移行完了まで維持)
+static/          # 旧サイトのフォールバック(Firebase Hosting配信元、Epic4完了まで維持)
 ```
 
-本番の実配信は現時点でもまだ `static/` 配下のHTMLです(Cloudflare移行 #263/#264 完了までの間、`main`ブランチへのpushは引き続き`static/`をFirebase Hostingへデプロイします)。`src/`配下のAstroサイトはこのブランチ上で開発中の新システムで、mainへのデプロイにはまだ組み込まれていません。
+本番はCloudflare Workers Static AssetsのWorker `bluemoon`から、`src/`のAstroビルド成果物(`dist/`)を配信します。Firebase Hostingと`static/`はFirestoreデータ移行(Epic4)が完了するまでフォールバック用に残します。
 
 ## 開発方法
 
@@ -47,11 +47,35 @@ http://localhost:8080/ でプレビュー
 
 ## デプロイ
 
-`main` ブランチにpushすると、GitHub Actions経由で `static/` がFirebase Hostingに自動デプロイされる(`.github/workflows/main.yml`)。
+### Cloudflare本番
 
-Pull Request作成時には、Astroビルドの型チェック・ビルド検証を行い、Firebase Hostingのプレビューチャンネルへデプロイしてプレビュー用URLをPRにコメントする(`.github/workflows/pr-preview.yml`)。
+`main`ブランチにpushすると、`.github/workflows/main.yml`が次の順で実行され、Cloudflare Workersの`bluemoon`へデプロイします。
+
+```text
+npm ci → npm run check → npm run build → wrangler deploy
+```
+
+初回だけ、GitHubリポジトリのActions Secretに`CLOUDFLARE_API_TOKEN`を登録してください。CloudflareダッシュボードでAccount → Workers Scripts → Editだけを許可したAPIトークンを作成し、値をGitHubのSettings → Secrets and variables → Actionsに保存します。アカウントIDは`wrangler.toml`の`account_id`を使用します。
+
+ローカルからデプロイする場合は、Cloudflare OAuthログイン済みの環境で次を実行します。
+
+```bash
+npm ci
+npm run check
+npm run build
+wrangler deploy
+```
+
+### Pull Requestプレビュー
+
+Pull Requestを作成または更新すると、`.github/workflows/pr-preview.yml`がPR番号ごとに`bluemoon-pr-<番号>`というWorkerを作成し、workers.devのプレビューURLをPRへコメントします。PRをクローズすると、そのプレビューWorkerを削除します。
+
+Firebase Hostingのプレビューは使用しませんが、Firebase関連設定と`static/`はフォールバック用に保持します。
 
 ## 関連リンク
 
 - [新システム構想 設計ドキュメント (Issue #212)](https://github.com/azumag/bluemoon/issues/212)
+- [Cloudflare移行 (Issue #263)](https://github.com/azumag/bluemoon/issues/263)
+- [Workers Static Assets移行PR #279](https://github.com/azumag/bluemoon/pull/279)
+- [本番Worker](https://bluemoon.tsubasa-azumagakito.workers.dev)
 - [旧Nuxt.jsコード (archive/nuxt-legacy)](https://github.com/azumag/bluemoon/tree/archive/nuxt-legacy)

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 
 export default defineConfig({
-  site: 'https://bluemoon-82c0b.web.app',
+  site: 'https://www.bluemoon.works',
   trailingSlash: 'ignore',
   integrations: [mdx()],
 });

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,3 @@
+/2024.html /events/2024 301
+/2025.html /events/2025 301
+/index.html / 301

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,9 @@
+name = "bluemoon"
+compatibility_date = "2026-08-05"
+account_id = "b9ab93f1f71640b6965a60c646b2392b"
+workers_dev = true
+
+[assets]
+directory = "./dist"
+not_found_handling = "404-page"
+html_handling = "auto-trailing-slash"


### PR DESCRIPTION
## 概要
Epic2(#263/#264)のCloudflare移行を実装。Astroのビルド成果物をCloudflare Workers Static Assetsにデプロイし、本番ドメインを切替済み。

## 変更内容
- `wrangler.toml`(新規): assets-only Worker(`bluemoon`)設定。`[assets] directory="./dist"`, `html_handling=auto-trailing-slash`, `not_found_handling=404-page`
- `public/_redirects`(新規): 旧URLから新URLへの301リダイレクト
  - `/2024.html` → `/events/2024`
  - `/2025.html` → `/events/2025`
  - `/index.html` → `/`
- `astro.config.mjs`: `site` を `https://www.bluemoon.works` に変更
- `.gitignore`: `.wrangler/` を追加

## 実測確認済み(本番)
- `https://www.bluemoon.works/` → 200(新Astroトップ)
- `/2024.html` `/2025.html` `/index.html` → 新URLへ301
- `/events/2024` `/events/2025` → 200
- `/events/2026` → 404
- 実Chromeで新サイト表示確認済み

## デプロイ状況
- workers.dev: https://bluemoon.tsubasa-azumagakito.workers.dev
- 本番切替: Worker Route(`www.bluemoon.works/*` → `bluemoon`、route id: `93bf9aa3f687481a86b587fc736290e8`)で実施。DNSは無変更で、復旧はルート削除のみ
- Firebase Hostingと`static/`はフォールバック用に残置

## 残作業(別issue/PR)
- main.ymlを`cloudflare/wrangler-action@v3`へ置換(`CLOUDFLARE_API_TOKEN` secret要設定)— issue #263
- pr-preview.ymlの置き換え
- README更新

Closes #263, #264
