### PR TITLE
ci: use Workers API for PR preview cleanup

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -99,8 +99,35 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Delete preview Worker
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: '4.119.0'
-          command: delete bluemoon-pr-${{ github.event.pull_request.number }} --force
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          WORKER_NAME: bluemoon-pr-${{ github.event.pull_request.number }}
+        run: |
+          account_id="$(sed -nE 's/^account_id[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' wrangler.toml | sed -n '1p')"
+          if [[ -z "$account_id" ]]; then
+            echo 'account_id is missing from wrangler.toml' >&2
+            exit 1
+          fi
+
+          response_file="$RUNNER_TEMP/cloudflare-delete-response.json"
+          http_status="$(curl --silent --show-error --retry 3 --retry-all-errors \
+            --request DELETE \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            --header 'Content-Type: application/json' \
+            "https://api.cloudflare.com/client/v4/accounts/${account_id}/workers/scripts/${WORKER_NAME}?force=true")"
+
+          case "$http_status" in
+            200|204)
+              echo "Deleted ${WORKER_NAME}"
+              ;;
+            404)
+              echo "${WORKER_NAME} was already absent"
+              ;;
+            *)
+              echo "Cloudflare delete failed with HTTP ${http_status}" >&2
+              cat "$response_file" >&2
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## Summary

- replace `wrangler delete` in the closed-PR cleanup job with the Cloudflare Workers Scripts Delete API
- read `account_id` from `wrangler.toml` and keep using `CLOUDFLARE_API_TOKEN`
- treat an already-absent preview Worker as a successful cleanup

## Why

`wrangler delete` performs an additional KV namespace API lookup. The least-privilege Workers Scripts token successfully deploys but cannot read KV namespaces, so PR-close cleanup failed with API error 10000.

## Validation

- YAML parsing passed
- `git diff --check` passed
- Cloudflare's Delete Worker API requires Workers Scripts Write, matching the configured Workers Scripts Edit permission
