### PR TITLE
[Epic3] newsのCMSプレビュー設定と日付入力改善 (#267)

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -44,9 +44,11 @@ collections:
     extension: md
     create: true
     delete: true
+    # お知らせはトップページのNewsLineに表示されるため、プレビューはトップページを開く
+    preview_path: /
     fields:
       - { name: title, label: タイトル, widget: string }
-      - { name: date, label: 日付(YYYY-MM-DD), widget: string, required: false }
+      - { name: date, label: 日付, widget: datetime, type: date, required: false }
       - { name: sns, label: SNSリンク表示, widget: boolean, default: false }
       - { name: body, label: 本文, widget: markdown }
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -24,7 +24,8 @@ const news = defineCollection({
     date: z
       .union([z.string(), z.date()])
       .transform((d) => (d instanceof Date ? d.toISOString().slice(0, 10) : d))
-      .pipe(z.string().regex(/^\d{4}-\d{2}-\d{2}$/))
+      .pipe(z.string().regex(/^\d{4}-\d{2}-\d{2}$/).or(z.literal('')))
+      .transform((d) => (d === '' ? undefined : d))
       .optional(),
     sns: z.boolean().default(false),
   }),


### PR DESCRIPTION
## 概要

#267 お知らせ(news)のトップページ自動反映の仕上げとして、CMS側の編集体験を改善します。

メインの自動反映機能(トップページのNewsLineへのnews表示)はPR #281で実装済み・動作確認済みのため、本PRではCMSプレビューを有効化します。

## 変更内容

### public/admin/config.yml
- newsコレクションに `preview_path: /` を追加 → CMSエディタのプレビューでトップページのNewsLineを確認できる
- dateフィールドのwidgetを `string` → `datetime` (`type: date`) に変更 → 日付ピッカーで入力形式(YYYY-MM-DD)を保証し、誤入力によるビルド失敗を防止

### src/content.config.ts
- newsのdateスキーマを空文字`""`に対応(datetime widgetは未入力時に `date: ""` を書き出すため)。空文字はundefined扱いとなりビルドが壊れない

## 検証済み
- `npm run check`: 0 errors / 0 warnings
- `npm run build`: 成功
- config.ymlはSveltia CMS公式JSON Schemaでvalid
- `date: ""` のnewsエントリを追加してビルド → トップページに表示され、空dateはリスト末尾にソートされることを実測確認
- 既存4件のnews(日付降順)の表示順を実測確認