### PR TITLE
[Epic3] CMS自動マージをGitHub App方式に変更 (#268)

### DIFF
--- a/.github/workflows/cms-publish.yml
+++ b/.github/workflows/cms-publish.yml
@@ -52,16 +52,25 @@ jobs:
           echo "Changed paths (all within allowed content paths):"
           echo "$changed" | sed 's/^/  /'
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CMS_APP_ID }}
+          private-key: ${{ secrets.CMS_APP_PRIVATE_KEY }}
+          owner: azumag
+          repositories: bluemoon
+
       - name: Merge cms-drafts into main
         env:
-          CMS_MERGE_PAT: ${{ secrets.CMS_MERGE_PAT }}
+          CMS_MERGE_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -e
-          if [ -z "$CMS_MERGE_PAT" ]; then
-            echo "::error::CMS_MERGE_PAT secret is not configured. Set it in repository secrets."
+          if [ -z "$CMS_MERGE_TOKEN" ]; then
+            echo "::error::GitHub App token could not be created. Check CMS_APP_ID / CMS_APP_PRIVATE_KEY secrets."
             exit 1
           fi
-          git remote set-url origin "https://x-access-token:${CMS_MERGE_PAT}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${CMS_MERGE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main

--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ CMSの書き込み先は `cms-drafts` ブランチです。公開操作がある
 
 #### CMS自動マージの前提
 
-`cms-publish.yml` がmainへマージするには、GitHub ActionsのSecret `CMS_MERGE_PAT` が必要です。mainのルールセット(copilot review)をバイパスできる権限が必要なため、リポジトリadminの権限で発行した **fine-grained PAT**(リポジトリ `azumag/bluemoon` 限定、Permissions: Contents → Read and write)を設定してください。
+`cms-publish.yml` がmainへマージするには、以下のActions Secretが必要です。mainのルールセット(copilot review)をバイパスできる権限が必要なため、**GitHub App**(例: `bluemoon-cms-bot`)を使用します(PATは2025年以降のGitHub仕様でルールセットをバイパスできません)。
+
+1. GitHub App作成(Webhook無効、Permissions: Contents → Read and write、対象リポジトリ `azumag/bluemoon` のみ)し、リポジトリへインストール
+2. リポジトリのルールセット「copilot review」のバイパスリストにそのAppを追加(設定済み)
+3. Secretsに登録:
+   - `CMS_APP_ID`: GitHub AppのApp ID
+   - `CMS_APP_PRIVATE_KEY`: GitHub Appのprivate key(PEMの全文)
 
 #### 画像の格納先
 

--- a/docs/editors-manual.md
+++ b/docs/editors-manual.md
@@ -58,7 +58,7 @@
 
 - **編集者の追加**: GitHub リポジトリ `azumag/bluemoon` の Settings → Collaborators からGitHubユーザー名を追加する
 - **公開の仕組み**: CMSの書き込み先は `cms-drafts` ブランチ。公開操作のcommitがあると `cms-publish.yml` が検証(ビルド+変更パス検査)後にmainへ自動マージし、mainのデプロイCIが本番へ反映する。`cms-drafts` へはコンテンツパス(`src/content/**`・`src/assets/events/**`・`public/images/**`)の変更のみが公開され、それ以外の変更が混ざると公開は失敗する
-- **自動マージの前提**: リポジトリのSecret `CMS_MERGE_PAT`(fine-grained PAT、リポジトリ限定・Contents read/write)が必要。未設定だと自動マージが失敗する
+- **自動マージの前提**: リポジトリのSecrets `CMS_APP_ID` / `CMS_APP_PRIVATE_KEY`(GitHub App `bluemoon-cms-bot` のApp IDとprivate key)と、ルールセット「copilot review」へのAppのバイパス登録が必要。未設定だと自動マージが失敗する
 - **マージ競合時**: `cms-publish.yml` が失敗するので、手動でmainをcms-draftsへマージして解決する
 - **CMSの構成変更**: `public/admin/config.yml`(リポジトリ内)を編集し、mainブランチへマージすると自動デプロイされる
 - **初回セットアップ**: [README.md](https://github.com/azumag/bluemoon/blob/main/README.md) の「コンテンツ管理(Sveltia CMS)」セクションを参照


### PR DESCRIPTION
## 概要

PATは2025年以降のGitHub仕様でルールセットをバイパスできない(fine-grained/classicとも実測で確認済み)ため、GitHub Appのインストールトークンでmainへマージする方式に変更します。

## 変更内容

- `cms-publish.yml`: `actions/create-github-app-token` でトークン生成(`CMS_APP_ID` / `CMS_APP_PRIVATE_KEY`)→ cms-drafts→mainの自動マージに使用
- ルールセット「copilot review」のバイパスリストにGitHub App `bluemoon-cms-bot`(App ID 4502556)を追加済み(APIで実施・反映確認済み)
- README/マニュアルをGitHub App方式の設定手順に更新

## 検証

- マージ後に実経路テスト(コンテンツpush→自動マージ→本番反映)を再実行します