### PR TITLE
[Epic3] cms-publish.yml: checkoutのextraheader無効化でアプリトークンpushを有効化 (#268)

### DIFF
--- a/.github/workflows/cms-publish.yml
+++ b/.github/workflows/cms-publish.yml
@@ -70,6 +70,9 @@ jobs:
             echo "::error::GitHub App token could not be created. Check CMS_APP_ID / CMS_APP_PRIVATE_KEY secrets."
             exit 1
           fi
+          # actions/checkout sets http.https://github.com/.extraheader with the GITHUB_TOKEN,
+          # which overrides credentials in the remote URL. Unset it so the push uses the app token.
+          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${CMS_MERGE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## 概要

実経路テストのルールスイートで判明: pushがgithub-actions[bot](GITHUB_TOKEN)として評価され、GitHub Appのバイパスが効いていませんでした。

## 原因

actions/checkout がリポジトリの git config に `http.https://github.com/.extraheader`(GITHUB_TOKEN)を設定します。これはリモートURLに埋め込んだ認証情報より優先されるため、アプリトークンが使われません。

## 変更

- マージステップで `git config --unset-all http.https://github.com/.extraheader` を実行してからアプリトークンでpush

## 検証(マージ後)

- main→cms-drafts同期 → コンテンツpush → 自動マージ → 本番反映の実経路テスト