### PR TITLE
[Epic4] 旧Firestoreのエントリー・投票データを静的JSONへエクスポート (#269)

### DIFF
--- a/scripts/export-legacy.mjs
+++ b/scripts/export-legacy.mjs
@@ -1,0 +1,174 @@
+/**
+ * 旧システム(archive/nuxt-legacy)のFirestoreデータを静的JSONへエクスポートする。
+ *
+ * 旧Firebaseプロジェクト bluemoon-82c0b の entries / votes / events を
+ * Firestore REST API(公開読み取り可)で取得し、
+ * - publishAgree === true のエントリーのみ
+ * - 個人情報(email, userId)を除去
+ * した形で src/data/legacy/ 配下に書き出す。
+ *
+ * 実行: node scripts/export-legacy.mjs
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PROJECT_ID = 'bluemoon-82c0b';
+const BASE = `https://firestore.googleapis.com/v1/projects/${PROJECT_ID}/databases/(default)/documents`;
+const OUT_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'data', 'legacy');
+
+// 旧イベントID → メタ情報(旧サイトのURL/スケジュール情報から判別)
+const EVENTS = {
+  '2pbLysWMNdNXnSvgBNr2': { volume: 1, year: 2020, title: 'オンラインフェス' },
+  'fe2ypz0gnDuSiY1t2KjG': { volume: 2, year: 2020, title: 'Bluegrass Lockdown Music Festival Vol.2' },
+  'VTH7oiZR2vmMCPgcW8xC': { volume: 3, year: 2021, title: 'Bluegrass Lockdown Music Festival Vol.3' },
+  'nWIe42DjxjQ4sircilRw': { volume: 4, year: 2022, title: 'Bluegrass Lockdown Music Festival Vol.4' },
+};
+
+function decodeValue(v) {
+  if ('stringValue' in v) return v.stringValue;
+  if ('booleanValue' in v) return v.booleanValue;
+  if ('integerValue' in v) return Number(v.integerValue);
+  if ('doubleValue' in v) return v.doubleValue;
+  if ('timestampValue' in v) return v.timestampValue;
+  if ('arrayValue' in v) return (v.arrayValue.values ?? []).map(decodeValue);
+  if ('mapValue' in v) {
+    return Object.fromEntries(
+      Object.entries(v.mapValue.fields ?? {}).map(([k, x]) => [k, decodeValue(x)]),
+    );
+  }
+  return null;
+}
+
+async function fetchAll(collection) {
+  const docs = [];
+  let token = null;
+  for (;;) {
+    const params = new URLSearchParams({ pageSize: '300' });
+    if (token) params.set('pageToken', token);
+    const res = await fetch(`${BASE}/${collection}?${params}`);
+    if (!res.ok) throw new Error(`GET ${collection} failed: ${res.status}`);
+    const data = await res.json();
+    for (const doc of data.documents ?? []) {
+      const fields = Object.fromEntries(
+        Object.entries(doc.fields ?? {}).map(([k, v]) => [k, decodeValue(v)]),
+      );
+      fields.__id__ = doc.name.split('/').pop();
+      docs.push(fields);
+    }
+    token = data.nextPageToken ?? null;
+    if (!token) break;
+  }
+  return docs;
+}
+
+const [events, entries, votes] = await Promise.all([
+  fetchAll('events'),
+  fetchAll('entries'),
+  fetchAll('votes'),
+]);
+
+// 公開同意フラグを尊重し、個人情報を除いたエントリー
+// - publishAgree === true のもの
+// - publishAgree フィールド自体が存在しないもの(Vol.1=同意チェックボックス導入前。旧サイトで公開済み)
+// - publishAgree === false は明示的な不同意のため除外
+const consented = entries
+  .filter((e) => e.publishAgree === true || e.publishAgree === undefined)
+  .map((e) => ({
+    id: e.__id__,
+    eventId: e.eventId,
+    name: e.name ?? '',
+    description: e.description ?? '',
+    fileURLs: String(e.fileURLs ?? '').trim(),
+    fileNames: Array.isArray(e.fileNames) ? e.fileNames : [],
+    videoType: e.videoType ?? null,
+    // 旧フォームの誤字フィールド(indibivual)も吸収
+    individual: e.individual ?? e.indibivual ?? null,
+  }));
+
+// 投票の正規化(entryKinds は JSON文字列の場合がある)
+const normalizedVotes = votes.map((v) => {
+  let entryKinds = v.entryKinds;
+  if (typeof entryKinds === 'string') {
+    try {
+      entryKinds = JSON.parse(entryKinds);
+    } catch {
+      entryKinds = undefined;
+    }
+  }
+  return {
+    id: v.__id__,
+    createdAt: v.createdAt ?? null,
+    entryKinds: entryKinds && Object.keys(entryKinds).length ? entryKinds : undefined,
+    entryIds: Array.isArray(v.entryIds) && v.entryIds.length ? v.entryIds : undefined,
+  };
+});
+
+// イベントごとの集計(投票は同意済みエントリーへのもののみ)
+const eventSummaries = {};
+for (const [eventId, meta] of Object.entries(EVENTS)) {
+  const eventEntries = consented.filter((e) => e.eventId === eventId);
+  const entryIds = new Set(eventEntries.map((e) => e.id));
+  const votesPerEntry = {};
+  for (const vote of normalizedVotes) {
+    const targets = vote.entryKinds
+      ? Object.entries(vote.entryKinds)
+      : (vote.entryIds ?? []).map((id) => [null, id]);
+    for (const [kind, entryId] of targets) {
+      if (!entryIds.has(entryId)) continue;
+      const agg = (votesPerEntry[entryId] ??= { kinds: {}, total: 0 });
+      agg.total += 1;
+      if (kind) agg.kinds[kind] = (agg.kinds[kind] ?? 0) + 1;
+    }
+  }
+  eventSummaries[eventId] = {
+    event: { id: eventId, ...meta },
+    entries: eventEntries,
+    results: votesPerEntry,
+  };
+}
+
+mkdirSync(OUT_DIR, { recursive: true });
+writeFileSync(
+  join(OUT_DIR, 'events.json'),
+  JSON.stringify(
+    Object.entries(EVENTS).map(([id, meta]) => ({ id, ...meta })),
+    null,
+    2,
+  ) + '\n',
+);
+writeFileSync(
+  join(OUT_DIR, 'entries.json'),
+  JSON.stringify(consented, null, 2) + '\n',
+);
+writeFileSync(
+  join(OUT_DIR, 'votes.json'),
+  JSON.stringify(normalizedVotes, null, 2) + '\n',
+);
+writeFileSync(
+  join(OUT_DIR, 'results.json'),
+  JSON.stringify(
+    Object.fromEntries(
+      Object.entries(eventSummaries).map(([eventId, s]) => [eventId, s.results]),
+    ),
+    null,
+    2,
+  ) + '\n',
+);
+
+const summary = {
+  exportedAt: new Date().toISOString(),
+  source: `Firestore REST API (${BASE})`,
+  entriesTotal: entries.length,
+  entriesConsented: consented.length,
+  votesTotal: votes.length,
+  events: Object.entries(EVENTS).map(([id, meta]) => ({
+    id,
+    ...meta,
+    entries: eventSummaries[id].entries.length,
+    votesCast: Object.values(eventSummaries[id].results).reduce((a, b) => a + b.total, 0),
+  })),
+};
+writeFileSync(join(OUT_DIR, 'summary.json'), JSON.stringify(summary, null, 2) + '\n');
+
+console.log(JSON.stringify(summary, null, 2));

--- a/src/data/legacy/entries.json
+++ b/src/data/legacy/entries.json
@@ -1,0 +1,1223 @@
+[
+  {
+    "id": "1HvlvZ1b0FcOtdCBhRVa",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "トイメンシャオ",
+    "description": "Banjoの原さとしとMandolinの竹内信次によるアコースティック・グラス・ロックユニット。\n今回は、不安な日々と収束への期待を込めて「近未来」という曲でエントリーです。",
+    "fileURLs": "https://youtu.be/Cv_ZzGNwfvI",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "1tHV4N2NIYdYXDHkBNnv",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "Unripened Stringplunkers",
+    "description": "結成10年ぐらいになるものの、『完熟することはない・いつまでも成長し続ける』という意味を込めて“Unripened Stringplunkers=まだ熟していない弦楽器弾きたち”笑 ブルーグラスを破壊…ではなく、ブルーグラスを主軸として、様々なジャンル・空気感にチャレンジ中。 今回の Lockdown Fes への準備中、F2F 会議・練習をしないことにより幾度となく崩壊しかけましたが、映像と音声をゴリゴリに編集し無理くり完成させました。 個性の集大成をお楽しみいただければと思います。 イカれたメンバをよろしくな!",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "2cwUikHBbvgXTsQXHh4O",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "箸休めsacred",
+    "description": "\"私もまた、六弦の立琴をもって、あなたをほめたたえます。わが神よ。あなたのまことを。イスラエルの聖なる方よ。私は、立琴をもって、あなたにほめ歌を歌います。\"\n詩篇　71篇22節\n聖書 新改訳©2003新日本聖書刊行会\n\n今Sacred復興の時来たれり",
+    "fileURLs": "",
+    "fileNames": [
+      "20200504onfes-wellmar.mp4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "2lITA6shVJoACheeNg80",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "Lonesome Garage Band",
+    "description": "Send My Love",
+    "fileURLs": "https://youtu.be/TWjV7SN_EXU",
+    "fileNames": [],
+    "videoType": "short",
+    "individual": null
+  },
+  {
+    "id": "2yTLiVZTDNmPwIZuHPCO",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "もひかん",
+    "description": "前回の楽しそうなご様子や、SNSで繋がる皆さんに背中を押して頂き14年振りにまたドブロを触ることになりました。\n相当なブランクでお耳汚しとは思いますが、40の手習いを優しく見守って頂けたら幸いです。\n曲は賛美歌のhow great thou art （というかロブアイクスのコピー）です。\n\n※エントリー条件に満たないほど短い動画なので、主催者さま側のご判断で可否願います。\n\nそれではどうぞよろしくお願いします！",
+    "fileURLs": "https://youtu.be/i8KMa5LAQR8",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "35swQJlOdgbl1NkZqOYz",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "Wellぷれいず…",
+    "description": "わぁい Bryan Sutton うぇる Bryan Sutton 大好き\n\n発表の場があるだけで自主練のモチベも変わったので運営様には頭上がりません\nサットン先生の弾いてた綺麗な曲を弾きます\n…今年はおとなしくしたつもりです\nゆっくりしていってね！\n",
+    "fileURLs": "",
+    "fileNames": [
+      "20211227_1_動画_うぇるP_完成.mp4"
+    ],
+    "videoType": "crafted",
+    "individual": true
+  },
+  {
+    "id": "3WyGKxbBwsdPr98tdrYt",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "自由人",
+    "description": "2011年、音楽性の違いにより結成。個々の単独思想から生まれる自由な音楽がウリ。名大OBバンドとして細く長く活動しているが、その存在は広く知られてはいない。",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "4CuunT0MYl6LsTWHj0Bs",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "どぶろひくぞう",
+    "description": "1930年代のReagalでJerry Douglasの”Who’s your uncle”を弾いてみました。",
+    "fileURLs": "",
+    "fileNames": [
+      "IMG_0237.MOV"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "4PX2FlBsmFzC6kDK6O6U",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "もっつ",
+    "description": "エセfoggy mountain breakdown(flatt&scruggsの初期バージョン)",
+    "fileURLs": "",
+    "fileNames": [
+      "IMG_6406.MOV"
+    ],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "4RMWA1rONUjNgdKaRMVg",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "ゴールデンロッドガールズ",
+    "description": "結成5年目名大OGゆるふわガールズバンドです❤︎chu!年々ゆるふわ度が増しちゃってごめん❤︎less filterな演奏をゆるゆるとお楽しみくださいまし( o̴̶̷᷄ ·̫ o̴̶̷̥᷅ )",
+    "fileURLs": "https://youtu.be/tEKUjyE5f_I",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "4kRBVUYYPO6UyLG2lWS3",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "新・Acoustic’s Sound Garden 2nd Edition",
+    "description": "今回、曲を作ったら思ったより長くなってしまい茶番を入れられませんでした。\nごくごくまじめな演奏動画になってしまい、すいません。\nしかし、僕の考えうる最高のブルーグラスを表現できた学生6年間の集大成だと思うのでぜひ最後までお楽しみください。\n僕に友達がいないばっかりにベース以外僕が弾いています。\nだれか共感してくれた人一緒に弾きましょう。\n申し訳程度にアテレコしたせいで全然運指あってないので目コピしないでください。\nギターとマンドリンは持ってませんでしたので後輩のギターだけ立てかけときました。\n良いお年を。",
+    "fileURLs": "https://youtu.be/1mjlb5cMyB0",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "6w0dm06G3mFV53flK7xo",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "ゆうと",
+    "description": "UndertaleというゲームのBGMを部屋にあったBluegrassの楽器で弾いてみました。急ごしらえで恐縮ですが、観て頂けると嬉しいです。Undertaleはいいぞ。",
+    "fileURLs": "https://youtu.be/wU5EriJvILI",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "782GjIs7BFaEbtM4lsnM",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "The Music of Masterpieces",
+    "description": "個人製作動画です。\nゲーム挿入曲をBG調に演奏してみました。\n箸休めにどうぞ。",
+    "fileURLs": "",
+    "fileNames": [
+      "Masterpieces.mp4"
+    ],
+    "videoType": "crafted",
+    "individual": true
+  },
+  {
+    "id": "82D0Sn0vfIl420ksdZ3A",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "インターネットやめろ",
+    "description": "去年英語圏を中心に世界的に大流行したアレを、自分で演奏する形でやってみました。 これをやれと呟いたんですよ。私の中のモンローが。",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "short",
+    "individual": null
+  },
+  {
+    "id": "88aLLojzePldhRNTAxRC",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "hanji",
+    "description": "30年前　友人が金沢を旅した時に書いた歌です。当時　録音したきり歌わなくなってしまっていたので　久しぶりに歌ってみました。",
+    "fileURLs": "",
+    "fileNames": [
+      "20230109柴垣.mp4"
+    ],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "8WdUkk1tpBBMdXkQVKP4",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "Blue Moon of Kenタニコ feat.ちょび",
+    "description": "こんばんは！神大ブルーグラスサークル4回生のBlue Moon of Kenタニコと、ちょびです！ロックダウンフェス初投稿させてもらいます！\n\n「君と唄ったブルームーン」は今回のオンラインフェスのために書き下ろした、出来立てホヤホヤのオリジナル曲です！ポップなメロディはもちろん、ブルーグラッサーならニヤけちゃうようなネタを散りばめた歌詞にもご注目！\n\nフェス当日はどうしても外せない用事ができてしまい、非常に非常に非常に残念ながらリアルタイムで参加できなくなってしまったのですが、アーカイブで楽しませてもらおうと思います！よろしくお願いします🤲",
+    "fileURLs": "https://youtu.be/SIHJiLfoo0A",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "8uGZK0Vg3woSrjbzUc0W",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "もやしちゃん",
+    "description": "前回は会場製作係でしたが今回は投稿動画でも参加します！\n少し毛色は異なりますが、フィンランドの伝統楽器カンテレにギターとバイオリンを加えて\n1曲だけですが曲を作って演奏しました。\nカンテレの響きをお楽しみください！\n",
+    "fileURLs": "https://youtu.be/uIPpZZTLv00",
+    "fileNames": [
+      "moyashichan.mp4"
+    ],
+    "videoType": "crafted",
+    "individual": true
+  },
+  {
+    "id": "960A88dcNfBYjlHJJMy0",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "marumi",
+    "description": "ブルーグラスを始めてもう40年になってしまいました。典型的な下手の横好きですが、好きなので、体が動く限り続けたいと思います。地上のフェスでもソロ演奏をよくやっていたため、今回はソロでエントリーさせていただきます。１）Eight More Miles to Louisville。サム・ブッシュが大好きなので、彼の演奏を参考にしました。２）Looking for a Reason。カントリー調のこの曲はCCRのアルバム「マルディグラ」から。古いカントリーっぽく聞こえますがジョン・フォガティのオリジナルです。お耳汚しではございますが、よろしくお願いいたします。お世話人様、こんな素敵な企画をありがとう！",
+    "fileURLs": "",
+    "fileNames": [
+      "2020042901.mp4",
+      "2020042902.mp4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "9U4jBdwW7V66iqIhxCQk",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "雑貨屋フレイヴァー",
+    "description": "東北大ブルーグラス同好会のOBバンド、雑貨屋フレイヴァーです。\n前回に引き続き、栃木、東京、そしてドイツから、リモートで動画を作って参加させて頂きます。\n届け、俺たちの魂のサウンド！\nブルーグラーース！！",
+    "fileURLs": "",
+    "fileNames": [
+      "BLMF2021雑貨屋フレイヴァー1227.mov"
+    ],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "9c2y6fz1txUVuuyjjDYt",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "米屋 with 原宿限界タピオカボーイズ",
+    "description": "勇気を持ってニャーンすること。それこそが人生で大事なんです。ニャーンが無ければ何も変えられない。ニャーンから始まるんです。みんな、わかってはいるがニャーンしない。ニャーンを面倒がる。ニャーンは自分に関係ないと思い込む。でも実はあなたの中にも素敵なニャーンがある。",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "short",
+    "individual": null
+  },
+  {
+    "id": "AfGw6sgQDxVbUACgWtCB",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "もっつ",
+    "description": "似非Cripple Creek",
+    "fileURLs": "",
+    "fileNames": [
+      "IMG_8204.MOV"
+    ],
+    "videoType": "crafted",
+    "individual": true
+  },
+  {
+    "id": "BKHc0NTwSzP5U0DFIXz1",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "Copper Kettles",
+    "description": "メンバーのほとんどは北大ブルーグラス研究会のOBです。Country Gentlemen の曲を中心に、他の曲もやるバンドです。18年と19年のフェスの動画をエントリーします。",
+    "fileURLs": "https://youtu.be/jMiR0P1oBuw",
+    "fileNames": [],
+    "videoType": "live",
+    "individual": null
+  },
+  {
+    "id": "BqIikJSykcxSvdESYFHL",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "米屋 with 原宿限界タピオカボーイズ",
+    "description": "ネットミームに影響され、お買い得ボーイズたちが「ブルーグラスが好きだ」という曲を作りました。",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "BzpRjtWQxnIxiZ8OtpT1",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "美女とBLUE",
+    "description": "ギター、マンドリンのデュオです。今回はソリッドなトラッド（歌詞が良い！）と、メロディアスなジャズ、＋aで参加します。\n\n追伸. オリジナル曲のアルバム制作がほぼ完成しましたので、またどこかで聞いて貰えると嬉しいです！よろしくお願いします！",
+    "fileURLs": "https://youtu.be/pD7ClzKkoqM",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "CAbhqYZI7P7SrPg9Zjqu",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "大倉 慎平",
+    "description": "普段は関東のアイリッシュセッション、オールドタイムジャムに参加。今回アイリッシュ、オールドタイムもエントリー可能&オンラインの気安さもあり無謀にも普段のフィールドの合わせ技でエントリー。",
+    "fileURLs": "https://www.youtube.com/watch?v=XOxlTYg9-pc",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "CZuB8zzuntOlN8VHenDn",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "Deep Blue Boys",
+    "description": "歌、リズム、ハーモニー、そして楽器、全てがそこそこの出来で調和できたそこそこのバンドです。お楽しみください。",
+    "fileURLs": "https://youtu.be/JlQlBK7fx-I",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "DMDEUdmPp8Mxu3TahIU8",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "Unripened Stringplunkers",
+    "description": "2011年に結成された「まだ熟していない弦楽器弾き」たち． ブルーグラスを主軸として， ジャズ，カントリーロックなど，メンバーの好きなジャンルを取り入れながら音楽の新しい方向性を模索している.\n\nまーしー：Eg，ふえ：Md，すーじー：Ag，きき：Bs，つばさ：Bj\n\n\n@usp_bluegrass \nhttps://twitter.com/usp_bluegrass\nhttp://uspweb.ifdef.jp/",
+    "fileURLs": "aaa",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "DwOU4dbdFZeKKBs3Rh3o",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "大椿山",
+    "description": "北海道大学ブルーグラス研究会の大椿山（おおつばきやま）です。\n\n同期3人で組んだバンドで、うちの歌姫である大久保の歌唱力とギター演奏、ベースの端山による安定した支えに、マンドリンの椿がおんぶにだっこされることで少人数ながらもバランスの良い演奏をお届けできるかなと思っています。\n\n次回Vol.4（コロナがおさまっても開催してほしいです）では北海道大学ブルーグラス研究会全体として参加させてください！",
+    "fileURLs": "https://youtu.be/WmB5y8WtdBs",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "FJ80qEthusSfDtf3kKyL",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "あぶらげ",
+    "description": "私はVRにかまけていて楽器の練習を怠っていました(首から札)",
+    "fileURLs": "https://www.youtube.com/watch?v=F_E1wYZMdnA",
+    "fileNames": [],
+    "videoType": "short",
+    "individual": null
+  },
+  {
+    "id": "HHVglTF1335QVkxvb7PF",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "The Old Folks",
+    "description": "このバンドは結成して1年半。名古屋のオールザットグラス、フィドルで活躍している籾山君をメインボーカルにしたバンドがやりたいという事で集まりました。メンバーは80年代 立命、関大のサークルで同学年だった照屋（Bj）、イノシシ（G）、籾山（G）、小寺（Mn）、そして岐阜の吉村さん（Bs）、名大の正岡くん（Fi）です。バンドのコンセプトは　“カオス(混沌)”。それぞれの個性、価値観がぶつかり合って、普通でない“カオスな状態”の演奏を目指しています。\n ",
+    "fileURLs": "https://youtu.be/j5fmt8fZWlk",
+    "fileNames": [],
+    "videoType": "live",
+    "individual": null
+  },
+  {
+    "id": "HjYq5VeG5T9wPVpPXFbk",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "Copper Kettles",
+    "description": "Country Gentlemenの曲を中心に、他の曲もやるバンドです。ギターとマンドリンはバンドメンバーで、北大ブルーグラス研究会のOBです。1曲だけバンジョーがゲストで参加します。\n★\n全体で11分35秒ありますが、バンジョーがゲストで参加する曲だけは公開済みの動画です (2分26秒)。",
+    "fileURLs": "https://youtu.be/075cSxzYbIw",
+    "fileNames": [],
+    "videoType": "mixed",
+    "individual": null
+  },
+  {
+    "id": "IOGyTrcOkyVftwUkNW9L",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "日本アルプス弦楽団",
+    "description": "京都のヨーデル娘を筆頭にしたヨーデル好きによるヨーデル好きのためのヨーデルをするバンド。\nさあ、画面の前の皆さんもご一緒に、ヨロレイヒー！＼(^o^)／",
+    "fileURLs": "１曲目：https://youtu.be/LwcWVJWt4eU\n２曲目：https://www.youtube.com/watch?v=Ksrkb6nJyNI",
+    "fileNames": [],
+    "videoType": "mixed",
+    "individual": null
+  },
+  {
+    "id": "IRKkyVrzPYoAbzef7udY",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "まいちゃん feat.AIきりたん",
+    "description": "神戸大学ブルーグラスサークルOBのまい（ユニクロ）です。\n一緒に音源つくる人もバンドも無かったので、頑張って一人でつくりました。\n聞いてくださると嬉しいです。",
+    "fileURLs": "",
+    "fileNames": [
+      "Mai_feat_Kiritan.mp4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "IhcaTBwekXIluANHJo4B",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": " B-rise",
+    "description": "A-rise という4人組のバンドで活動してます。\nBluegrassのスタンダードやSSWの曲をベース\nに日本語の唄を演ってます。ここ数年、一年に2回程下北沢\nでライブもやったりもしてます。\n今回は二人だけで安直に名前はB-rise\n軽い気持ちでインスト曲を選んでよかったのでしょうか...（汗)\n曲名は「Arkansas Traveler」です。\nちょっとの暇つぶしにでもなれば幸いです。\nよろしくお願いします。",
+    "fileURLs": "https://youtu.be/P_69ijQbo_M",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "K1sQugtbZOcsmBUv3gdi",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "Copper Kettles",
+    "description": "Country Gentlemenの曲を中心に、他の曲もやるバンドです。\nギターとマンドリンは北大ブルーグラス研究会のOBで、バンジョーは京大軽音楽部のOBです。",
+    "fileURLs": "https://youtu.be/alOeqwvaCFQ",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "KcauPkBqaeexSDYqMSyy",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "雑貨屋フレイヴァー",
+    "description": "2007年、東北大ブルーグラス同好会の部室に居合わせた面々で結成。今ではそれぞれ社会人となり、家業の都合やメンバーの海外転勤などにより活動が少なくなっていましたが、今回リモートセッションで距離、時差の壁を越えて参加します。Lockdown fesのために新曲2曲を書き下ろしてきました！",
+    "fileURLs": "https://youtu.be/v975rI-w7zw",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "LEYd0aUMCgZXboSQ0IeF",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "BLUEST BELIEVERS",
+    "description": "2019年夏、東北大のブルーグラス信者たちによって結成されたフェスバンドです。\n二十歳からアラフォーまで幅広い年齢層でお送りします☆\nお前ら...心に宿った青い炎が消えないかぎり...信じることを...やめるんじゃねぇぞ...！\nDon’t stop believing！！！",
+    "fileURLs": "https://youtu.be/GD2EfC-zbi8",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "MMWYUDAtbNPw6Ugfmgpt",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "まいばす",
+    "description": "非日常の中で感じる日常と、日常の中で演出した非日常と、それらを内包して回っていく個人的生活について。",
+    "fileURLs": "https://youtu.be/oTx8EQukptI",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "N7D2PFyi98GejHo01RGN",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "引きこもりジジイ",
+    "description": "63歳で、一からアパラチアン・ダルシマーを学び直した、来年70歳になるジジイです。\nアパラチアン・ダルシマーを、フラット・ピッキングとフィンガー・ピッキングで弾きます。\nドライヴのかかった、かっこいいブルーグラスの合間に、もたもた弾きます。休憩時間としてお使いください。",
+    "fileURLs": "",
+    "fileNames": [
+      "00、動画_第2回LockdownBG　Fes.用Dulcimer演奏集.mp4"
+    ],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "NYmMaq4dSroiGMhLfNcU",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "げんきっきモンキッキ + The Time in My Hands",
+    "description": "関東を中心に活動する若手オールドタイムバンド「The Time in My Hands」と、ブルーグラスを中心に演奏する名大OBバンド「げんきっきモンキッキ」が一緒に演奏しました！元気なオールドタイムをお聞きください！",
+    "fileURLs": "https://youtu.be/1tA0LlM7VSg",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "O4uFGgf5oWP2XvT5AgE4",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "ヒラサワリョータ",
+    "description": "栃木でマンドリン弾きながらパティシエしてます！\n今回はオリジナルインストを2曲弾かせていただきます。\n\nまた、毎週金曜日に自分のYouTubeチャンネルにてオリジナルのマンドリン曲をアップしています！\n会場の皆さま！フェスをご視聴の皆さま！「ヒラサワリョータ」で検索、からのチャンネル登録・高評価お待ちしております！！！",
+    "fileURLs": "https://youtu.be/4S0Ii5ntwko",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "OTcgLMwfT8LQMiVHN00Z",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "コーラスウォーター",
+    "description": "名古屋を拠点に活動しています、コーラスウォーターと申します。主にブルーグラスの楽器編成で日本語のオリジナル曲を演奏しています。\n今回はオンラインフェスに参加するにあたって、ブルーグラッサーにとって馴染み深い場所で（勝手に）演奏しました。",
+    "fileURLs": "https://youtu.be/LyfZxxz_JJQ",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "P5IceGASZKgcOd8ioEDj",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "Deep Blue Boys",
+    "description": "東京中心に活動する高年齢ブルーグラスバンド。昨年5月に催したライブハウスでの演奏から3曲お届けします。前回出場の際はお蕎麦をいただいたので、今回は節分の豆を狙いにいきます。",
+    "fileURLs": "https://youtu.be/tRUKE5ycDLw",
+    "fileNames": [],
+    "videoType": "offline",
+    "individual": null
+  },
+  {
+    "id": "PltjutVS2TUS0NLkxiv6",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "Lonesome Garage Band",
+    "description": "Where is my destination?",
+    "fileURLs": "https://www.youtube.com/watch?v=XsRRmWEi5pE&feature=youtu.be",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "PqEK5LjNPZPyMJputeQ3",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "のれん",
+    "description": "仙台でドブロプレイヤーとして活動している “のれん”こと野崎廉です\nドブロでやっていこうと決めて最初に作ったソロドブロインスト”森と凪”\nドブロをブルーグラス界隈以外の人に知ってもらいたいと思って作ったYOASOBIカバー、そしてことし発売した自分のミニアルバムにも収録したAngeline the bakerです！\nどの動画もドブロの音のみで作られています\nぜひお楽しみください！",
+    "fileURLs": "https://youtu.be/Uiwy4-K_2EU\nhttps://youtu.be/X9d3A3FN0jw\nhttps://youtu.be/Dd4cYM2DX20",
+    "fileNames": [],
+    "videoType": "mixed",
+    "individual": true
+  },
+  {
+    "id": "QbPSsjzAsadU2aQVRDNs",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "世界の山ちゃん",
+    "description": "はじめまして、東北大学ブルーグラス同好会所属の「世界の山ちゃん」というバンドです。\nちょうど1年前に結成されたばかりのフルバンドで、王道のトラッドのブルーグラス曲から、少しアイリッシュ調の曲など幅広く演奏しております。\n今回は今年2月に仙台のスターダストというライブハウスで行われたライブより、5曲を抜粋してお届けします。\nご興味を持っていただけた方は、ぜひ東北大学ブルーグラス同好会のTwitter、そしてYouTubeチャンネルをご覧ください。\n参考：東北大学ブルーグラス同好会Twitter　(https://twitter.com/tohokubluegrass)\n　　　YouTubeチャンネル　(https://www.youtube.com/channel/UCEO5hmdWKILYmHBQipM048Q?view_as=subscriber)",
+    "fileURLs": "【5月3日(日)　22:00　動画に間違いがあり訂正したためYoutubeのリンク・添付ファイル共に変更されております】\n\nhttps://www.youtube.com/watch?v=fttQ5Qrs4ME\n※直接アップロードしておりますmp4ファイルと、内容は全く同じです。\nyoutubeとmp4ファイル、都合の良い方をご利用いただければと思います。",
+    "fileNames": [
+      "[Re] Sekai no Yamachan.mp4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "Re4ZMBXn8zybhRbusDPq",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "Lonesome Garage Band",
+    "description": "短いですが聴いていただけたら嬉しいです。",
+    "fileURLs": "https://youtu.be/ICX5O7vIt_o",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": true
+  },
+  {
+    "id": "SDwkZJMmGa1HW1M1u9Rv",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "Hiroshi Masuda",
+    "description": "還暦バンジョー弾き、増田と申します。クリスマスナンバー1曲「Sleigh Ride」と、還暦ギタリスト高橋新吾とのユニット「マスダスインゴ」によるBeatles Medleyをエントリーさせて下さい。",
+    "fileURLs": "https://youtu.be/Q5BpK3lre5U https://youtu.be/hmpPTTYvrCU",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "SE2hd8nSxiXvHhz84rVL",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "A-RISE",
+    "description": "調布・仙川で活躍する味のあるバンドです。リーダーアライの魂のこもった歌詞に惚れてください。下北沢「らうん」にてたまにライブしています。今回はその「らうん」での演奏を2曲，エントリーします。",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "live",
+    "individual": null
+  },
+  {
+    "id": "SOlp4sz006CxeLNzlMfn",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "Lingerie Douglas",
+    "description": "本人は多分覚えて無いとはおもいますがドブロの巨匠Jerry Douglas氏からランジェリー ダグラスを名乗っても良いとのお許しを頂いているので今回はランジェリー ・ダグラスでエントリーします。\n曲はオリジナルの”Island Christmas “とFlatt & Scruggsのドブロ弾きJosh Gravesの”Foggy mountain rock”です。\n",
+    "fileURLs": "https://youtu.be/e8WfacmTPuw",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "Sd1rXqWwV2pLiAotf15r",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "野村昌毅",
+    "description": "「私が歌う理由」谷川俊太郎とラングストン・ヒューズの詩に曲をつけました。オートハープでの弾き語りです。2017年7月2日 第7回 隅田川フォークフェスティバルにて。使用楽器：Kotokoto Harp Blue Night（ウォルナット/マホガニー）\n\n1980年、東京生まれ。主に都内でオートハープとギターの弾き語りをやっています。日本画作品のホームページ→https://nomuramasaki.jimdofree.com/",
+    "fileURLs": "https://www.youtube.com/watch?v=k2OPdIFjRdc",
+    "fileNames": [],
+    "videoType": "offline",
+    "individual": null
+  },
+  {
+    "id": "T5u178K0dw8wXdUTU5oU",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "引きこもりジジイ",
+    "description": "70歳のジジイが、断続的に53年やってきた「フレイリング～クローハンマー」スタイルの非常に簡単な習得法と、あまり知られていない弾き方、意外かもしれない応用法を「次代を担う方達」への何かしらのヒントとして時間一杯、ぎっしり詰め込んで残しておきたいと参加します。\n右手に限っているので「ブルーグラス・バンジョー弾き」ならば簡単に想像がつき、様々なリズム・色々な音楽への応用が出来るでしょう。クローハンマーに自由を！",
+    "fileURLs": "",
+    "fileNames": [
+      "出、改、15分38秒版_動画_3rd　LO　Fes.参加用.wmv"
+    ],
+    "videoType": "crafted",
+    "individual": true
+  },
+  {
+    "id": "UE3l1iIBSx04dO55O7Il",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "ジャンクション",
+    "description": "ブルーグラスに用いる楽器でサカナクションのアレンジを試みる実験的バンド\nお馴染みの楽器から出される音色で、表拍に強調を置いたテクノ・ダンスサウンドに挑戦します\nサウンドエンジニアリングガチ勢によるミックスは必聴です",
+    "fileURLs": "https://youtu.be/ekgZ62uuKbg",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "Ul41ZrFYemqp85T7BPHb",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "マスダスインゴ",
+    "description": "3回目の出場 \"マスダスインゴ\"です。少し古いですがコロナ前の墨田ストリートジャズフェスでの演奏です。揺れるバスの中で40分間、Beatlesを中心に43曲を弾きまくったものの一部を切り取りました。曲目はどれもBeatlesの有名曲です。",
+    "fileURLs": "https://youtu.be/b7wF2ToaOfI",
+    "fileNames": [],
+    "videoType": "offline",
+    "individual": null
+  },
+  {
+    "id": "VAwpVt4j0FlXVUdDyuAz",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "B-rise",
+    "description": "3回目の開催ありがとうございます！公園でコツコツレパートリーを増やしておりますが、こういうイベントがあると練習にも熱が入るのでありがたいです！今回は2曲録りました！拙い演奏ですが、楽しんでいただけたら嬉しいです。",
+    "fileURLs": "",
+    "fileNames": [
+      "IMG_2013.mp4"
+    ],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "VBIvC35Doq8OvTcDdjAn",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "テイター安田ともっつ",
+    "description": "turkey in the straw\nnorth carolina breakdown",
+    "fileURLs": "",
+    "fileNames": [
+      "IMG_9665.MOV",
+      "IMG_0138.MOV"
+    ],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "WBYj13bCP2p1Dm6A3OtT",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "真・Masaokas' Band",
+    "description": "友達がいないなら全部ひとりで弾けばいいじゃない。\n……体力的に1曲が限界でした。\nもっと聞きたいと思ってもらえたあなた、最近CD作りました。\n完成した瞬間コロナでライブ全部ぶっ飛んで在庫めっちゃあります。\n金はすっからかんです。\nよかったら買ってください。\n購入フォーム：https://forms.gle/PA6bZ9hv99nQWJSZ7\n\n限界楽器紹介\nフィドル(ミュート)\n古着詰め込んだバンジョー\nマンドリン\nエレキギター(アンプラグド)\nそもそもベースを持っていない",
+    "fileURLs": "",
+    "fileNames": [
+      "Masaokas' Band.mp4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "WoBFIInL5baLfqFv7bij",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "Bluegrass Babe",
+    "description": "ブルーグラス系ユーチューバー　武谷健をリーダーとするオンラインブルーグラスバンド。\n2ヶ月に一度、Western Acoustic Musicの配信ライブにて演奏動画を公開！チャンネル登録よろしくお願いします！",
+    "fileURLs": "1個目： https://youtu.be/gVrO0HtEFw0\n2個目： https://youtu.be/1V7r7hEPSmM",
+    "fileNames": [],
+    "videoType": "mixed",
+    "individual": null
+  },
+  {
+    "id": "Wq3zNPe4b4VaFAbamrEW",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "位牌/真夏日",
+    "description": "maiBass",
+    "fileURLs": "https://youtu.be/98eY6NkrD2g\n(直接アップロードしたものと同じです)\n(新しいものに置き換えました)\n(3度目の正直？的な？みたいな？)",
+    "fileNames": [
+      "BLMF3_maiBass.mov"
+    ],
+    "videoType": "crafted",
+    "individual": true
+  },
+  {
+    "id": "Xim7WGtgz3kvlKyWR4Tm",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "かみおかwithぴぐもん",
+    "description": "2014年に結成したユニット。結成6年目間近にして初の演奏です。ギターを弾くおじいさんと歌のお姉さんになりたい。和牛を食べるためにエントリーしました。和牛食べたい。本当はリペアもしたい。",
+    "fileURLs": "https://youtu.be/WMzqLAV2Dc4",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "Z2kTfP53OAu0mBEvCBOC",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "ヤンボーマーボー今日も天気だ仲良しファイターズ",
+    "description": "「ええ感じやん！」って思ってもらえるバンドを目指し、\nブルーグラスやカントリーなどの曲を、\nブルーグラスらしからぬスタイルで演奏するバンドです。\nブルーグラス進化系ハイブリットヤンボースタイル！って呼んでもらっていいですか？！（笑）\nよろしくお願いいたします！\n\nこの動画は、昨年10月に神戸の宇治川音楽祭で演奏した時の動画（YouTubeに公開済み）を、\nBLMF用に再編集し直した未公開のBLMF.versionの動画（限定公開）になります。",
+    "fileURLs": "https://www.youtube.com/watch?v=9FdHQmGrDsU",
+    "fileNames": [],
+    "videoType": "offline",
+    "individual": null
+  },
+  {
+    "id": "ZR4QzjmHlE5KUDHpNVdZ",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "ちの井本",
+    "description": "BanjoとVocalでなんかやります",
+    "fileURLs": "未作成です",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "ZZZqW63G39tvaGdfrRQp",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "KingSize",
+    "description": "浜松のオリジナル・ブルーグラスバンド、KingSizeです。約20年間、地元浜松を中心に「元気の出る音楽」を発信し続ける、イカスバンドです。メンバーは向かって左からmasa(cho,bass)、てらだっち(vo,banjo)、コータ(cho,guitar)の3人です。動画の演奏曲は、1曲目「僕ら100年の夢を見る」2曲目「心配性」です。どちらもてらだっちのオリジナル曲です。ヨロシクお願いしまーす。",
+    "fileURLs": "https://youtu.be/BVpJjWl2bTM",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "ZjTqZSF8v6ibKC9BLNvf",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "B-rise",
+    "description": "あけましておめでとうございます！\n今年も開催されるという事でありがとうございます！\n公園生活も長くなって来ましたが\n今回は歌もの、一発どりに挑戦しました。\n曲は\n京王線の唄\nWhiskey Before Breakfast \n 遠くまで行くんだ〜I’ll fly away 〜\n楽しんでいただけたら嬉しいです！\n\n",
+    "fileURLs": "https://drive.google.com/file/d/1X32sX_hfLIDJ5gYD3iLVIvnWuhXjuJE8/view?usp=drivesdk",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "adXryDV5Ba58KFCflEmn",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "Harrids",
+    "description": "バンマス・Harry矢那瀬の無節操な嗜好にお付き合いする仲間が集ったバンドです。３ヶ月に一度、銀座RockyTopに出演するほか、関東〜東北のフェスにも積極的に参加しています！！",
+    "fileURLs": "",
+    "fileNames": [
+      "Harrids_Lockdown.mp4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "aeZxzoBE2AakMFhmjSbH",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "自由人 :-)",
+    "description": "2011年、音楽性の違いにより結成。個々の単独思想から生まれる自由な音楽がウリ。名大OBバンドとして最も長く活動しているが、最も知名度が低い",
+    "fileURLs": "aaa",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "aj9EZuofNLKb1tZuHa30",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "まるみ",
+    "description": "ブルーグラスを始めてもう40年になってしまいました。典型的な下手の横好きですが、好きなので、体が動く限り続けたいと思います。Long Black Veilをソロで演奏させていただきました。トラディショナル曲のように聞こえますが、1950年代のレフティ・フリーゼルのカントリーヒット曲。ブルーグラス系はもちろん、The Bandはじめ多くのアーティストがジャンルを超えて取り上げています。珍しいところではミック・ジャガーも。Webまるみというサイトをやっています。ブルーグラスフェスが大好きで、がんばってフェススケジュールをフォローしています。今年はとても残念な年でしたが、来年はぜひ、フェス会場で皆様とお会いできますように！",
+    "fileURLs": "",
+    "fileNames": [
+      "マイムービー.mp4"
+    ],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "ajLr7q2Mnsp5W44PZCtj",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "B-rise",
+    "description": "B-rise です。  なかなか室内で集まっての練習も憚られる日々、練習はもっぱら近所の公園。  憧れの名曲”Yankees revenge “を目指すも、撮影したものを見てみると、元曲にみなぎる殺気が感じられない､､､と言う事で”calm revenge “”穏やかな復讐”と言う題にしました。  最後まで聞いて頂ければ嬉しいです。",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "alZ4uc824NdPJWlse0yX",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "美女とBLUE",
+    "description": "ギターとマンドリンのバンドです。オリジナル4つでのエントリーです。こんな感じでブルーグラスを背景にしつつ演奏の幅を広げれたらと思ってます。",
+    "fileURLs": "https://youtu.be/CFzpmP7wCok",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "b4CeAZa34JgSnIWOHM5t",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "ゆうと",
+    "description": "1曲だけですが箸休めに…",
+    "fileURLs": "https://youtu.be/J0nRi5fLLbw",
+    "fileNames": [],
+    "videoType": "live",
+    "individual": null
+  },
+  {
+    "id": "bd4isAFeOG1KpzKFUDgK",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "Lonesome Garage Band",
+    "description": "Song for a Winter's Night",
+    "fileURLs": "https://youtu.be/eaeVChlFC-0",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "cajLYmAzjVQwaU7aQFlw",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "ランジェリー・ダグラス",
+    "description": "毎度お世話になります。\n今回はLingerie Douglas ではなくランジェリー・ダグラスでエントリーさせていただきます。ドブロ好きの方はもちろんそうでない方にも観て頂きたいです。調子に乗って撮ってたら11分になってしまいました。ごめんなさい。4曲のうち3曲はオリジナルで攻めたいと思います。よろしくお願い申し上げます。",
+    "fileURLs": "https://youtu.be/c5dNCqRK508",
+    "fileNames": [],
+    "videoType": "mixed",
+    "individual": true
+  },
+  {
+    "id": "dNxTUIHFUKweBpOfWblH",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "米屋 with 原宿限界タピオカボーイズ",
+    "description": "概念空間に舞い降りた究極の爽やかボーイズバンド。長く愛され，様々な形態変化を見せていったブルーグラスの「あの」名曲を我々なりの爽やかでバウンシーかつソリッドなアレンジでお届けします。お嫁さん募集中です。ナァ…どうャ…？",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "fACvkZ3xDfLjCmcd6yP1",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "Unripened Stringplunkers",
+    "description": "スージーの命題について、演奏を通して考えていきます。",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "gLRbyuKUvJDKRXmsn3Pj",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "dixie mohicks",
+    "description": "本業がかなり忙しく間に合うかわかりませんが、取り敢えず白塗り部門にエントリーいたします。いま紹介されているのであれば間に合ったんでしょう。\n\n戦争が1日でも早く終わることを願い、また正しいことを貫く彼女たちに敬意を表してdixie chicksのI'm ready to make niceを選びました。\n\n見どころは先月この曲の為に、メルカリで買った6800円のフィドルです。\n\n\n\n工房も年末から少々おろそかにしておりますが、お山のフェスに行けない私にはここで皆さんとお会い出来ることを楽しみに、楽器を維持しております。\n\n本年もどうぞよろしくお願いします。\n\nもひかん\n\n",
+    "fileURLs": "https://youtu.be/EKX-IYMbr9Q",
+    "fileNames": [
+      "IMG_3567.MOV"
+    ],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "gj485A0x7bjZzfG6ZL2b",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "コーラスウォーター",
+    "description": "名古屋を拠点に活動中のブルーグラスポップバンドです。主にブルーグラスのカバーや日本語のオリジナル曲を演奏しています。",
+    "fileURLs": "https://youtu.be/wtSgvulnSng",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "h5bp3jponsPdaDH9zu8p",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "ゴールデンロッドガールズ",
+    "description": "結成3年目のゆるふわガールズバンドです。聞いて楽しい&弾いて楽しい演奏を目指して、トラッド曲からポップな曲まで幅広く挑戦中です！がんばるぞ〜〜💪💪",
+    "fileURLs": "https://www.youtube.com/watch?v=hVrDejRHZew&feature=youtu.be",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "hTZ79HtV8BYwSNsBlkpf",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "Pacifice Express",
+    "description": "新宿三丁目のカントリー酒場「居留地」で、毎偶数月の第２土曜にライブを続けるブルーグラスバンド。マンドリン＆フィドルのリーダーの元、比較的若めのバンジョーをギター、ベースが支えます。鉄壁のコーラス目指し、歌い続けています♪",
+    "fileURLs": "https://www.youtube.com/watch?v=byeudiA3zPA",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "hdC7w49jP4VMXSHdX7WS",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "Master of Traditional Bluegrass",
+    "description": "Bill Monroeを始めtraditionalなブルーグラスを中心に渋くキメます！\nfd テイター安田\nbj もっつ\nmd アッキー　\ngt 村田\nbs 武田(特別ゲスト)",
+    "fileURLs": "https://youtu.be/JFZiEdw-nHM",
+    "fileNames": [],
+    "videoType": "live",
+    "individual": null
+  },
+  {
+    "id": "ipyRjzqecWtP3thsyixV",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "Stay Home, stay mandolin",
+    "description": "オールドスクールなブルーグラスをマンドリン で弾いてみました",
+    "fileURLs": "https://youtu.be/pKF4sblYAbo",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "j6golAxQpsvYWSNdplsr",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "マーマレードボーイズ",
+    "description": "みなさま\n初めまして、大谷大学OBのマッキーです。\n大谷大学OBのマッキーとひらりんが1年の時、「いつかツインギターのバンドを絶対組もう！」と言っていたが、\n誰も参加する人がおらず、\n残ったのはギター２つと野郎が２人、あとOOOが２本、、、、、、、、、、、、、、、\nギター初心者だった二人が切磋琢磨など一切せず！互いに好きなように楽しんだ３年間の一興として、楽しんでもらえれば幸いです。\n野郎２人が自分達なりに、無い頭絞ったんで、生温かい目でみてもらえれば恐縮です。\nそれではお聞きください、「マーマレードメドレー♪」\n\nマッキー\n",
+    "fileURLs": "https://youtu.be/z1dKAt10RcI",
+    "fileNames": [],
+    "videoType": "live",
+    "individual": null
+  },
+  {
+    "id": "jQO6Vt7XMFzHo1Wa8aUy",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "masaoka and friends",
+    "description": "これまではネタ動画系に走っていましたが、今回は真面目に弾きました。\n編曲が好きで巷の曲を聴くと頭でバンジョーのロールが流れてしまいます。\n今回は選りすぐりのアニソン5曲をブルーグラス楽器で弾いてみました。\nサークルを卒業するなりPopsやら軽音楽に浮気してしまう先輩の心に届けば幸いです。\nこだわりポイントとしては各楽器1トラックで電子的な編集も入れてないので皆さんのブルーグラスバンドで明日から演奏可能です。\n\n最後になりますが、締め切り2日前に曲決めて深夜の0時からスタジオ入りしてくださったボーカルのはおさん、ベースのたけがみさん、本当に本当にありがとうございました。",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "jSyhnowRfbtQWx5F70Gh",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "もっつ",
+    "description": "steel guitar rag",
+    "fileURLs": "",
+    "fileNames": [
+      "IMG_5234.MOV"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "jjuroEWrFNmuaJr39BNh",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "れいじーぴっかーず",
+    "description": "こんばんわ。れいじーぴっかーずです。京都で活動していたバンドです。\n昨年末にコーラスウォーターさんに名古屋に呼んでいただいたときの演奏をお送りいたします。\n３曲目のあとの、まおくんの携帯が壊れた話もよかったら聞いてください。",
+    "fileURLs": "",
+    "fileNames": [
+      "れいじーぴっかーず_Bluegrass Lockdown Music Festival.mp4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "kXnMhFzCGMVwHQheTZFq",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "Well & Gone",
+    "description": "滋賀と岐阜のトニーライスオタクらによる貴重な不定期会合のシーン\n絶賛仲間募集中だよ（ﾆﾁｬｱ　Twitter -> @Welpurgis @gt9822\n\n追記：工房もひかん（仮）さん素敵なストラップ×2ありがとうございました！！",
+    "fileURLs": "",
+    "fileNames": [
+      "20230128_BLMF4_Well&Gone_1.mov"
+    ],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "khNReMKhXEYC3vpJ1nFD",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "Copper Kettles",
+    "description": "Country Gentlemenの曲を中心に、他の曲もやるバンドです。\nギターとマンドリンは北大ブルーグラス研究会のOBで、バンジョーは京大軽音楽部のOBです。\n★動画は期限までに新規動画に変更します。",
+    "fileURLs": "https://www.youtube.com/watch?v=K3voOHS1wcc",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "knpmWzgEfVNGpNlC1j8y",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": " Master of Traditional Bluegrass",
+    "description": "Fiddle、\"Tater\"安田と、Banjo、手嶋のトラッド志向バンドも何だかんだ結成から3年が経過し、コロナの間を縫いながら地域の東西行ったり来たり細々と活動してきました。 今回もオンフェス、渋めの選曲で参戦させていただきます！新たに女性ベースを加えパワーアップしたサウンドでお送りいたします。 Fiddle: \"Tater\"安田、Banjo:手嶋、Mandolin:鈴木アッキー、Guitar:村田、Bass:菅沼",
+    "fileURLs": "",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "m1EL8CRUCIkbDfDDkhHY",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "松本達也",
+    "description": "北大ブルーグラス研究会のOBで、Copper Kettlesのギター弾きです。YouTube ページの紹介用に作成した動画で参加します。",
+    "fileURLs": "https://youtu.be/73ShYs9bYdo",
+    "fileNames": [],
+    "videoType": "short",
+    "individual": null
+  },
+  {
+    "id": "mardYDNcz6k3dsh1cBRh",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "水木ゆうこ＆サウザンドリバー",
+    "description": "2020年第二回オンラインフェス参加用に再編集！H・M・フォーク村「小さな仲間フォーク・コンサート」水木ゆう子＆サウザンドリバーライブ演奏。ボーカル＆ギター：畠山和治、ハーモニー＆ベース：野口冨次郎、バンジョー：石切山平仁。尚、水木ゆうこ、荒井信夫、小島慎司は所用でお休み。演奏は三十数年前のものです。よろしくお願いします。",
+    "fileURLs": "https://www.youtube.com/watch?v=8J1BQ6vz46E",
+    "fileNames": [],
+    "videoType": "live",
+    "individual": null
+  },
+  {
+    "id": "nPyr6a1xpzrEoMOYiVVs",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "Instead of Net",
+    "description": "DAWGばっかり何十年もやってるバンドです。\n今回は、一番ポピュラーな（？）EMDという曲でエントリーします。",
+    "fileURLs": "https://youtu.be/72_DYOuoQP4",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "o7LuAlWNG7OUFaLyo0KE",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "コーラスウォーター",
+    "description": "名古屋を拠点に活動中のブルーグラスポップバンドコーラスウォーターです。今回は演奏動画ではないのですが、アルバム『めがねと水玉』を録音した際のメイキング映像でエントリーします。",
+    "fileURLs": "https://youtu.be/9U3AgbaKcYI\nhttps://youtu.be/rm_zRUgFmbQ",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "pVqfeRg8lbJQowz24pD2",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "Two Crie Stringband",
+    "description": "トゥークリエストリングバンドと読みます。実はバンドじゃなくてデュオです。\nオールドタイムやフォークを中心にお届けします！\n今回はバンドで演奏できました！やったー！！\nオールドタイムに興味を持った方はこちらのTwitterアカウントのフォローをぜひお願いします🙇‍♀️\n→@OldTimeJP",
+    "fileURLs": "https://youtu.be/hU8xbB1WdSI",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "qYZMG26eovIhn9j217aV",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "ジャンクション",
+    "description": "ブルーグラスに用いる楽器のみでサカナクションのアレンジを試みる実験的バンド\n\nお馴染みの楽器から出される音色で、表拍に強調を置いたテクノ・ダンスサウンドに挑戦します",
+    "fileURLs": "https://youtu.be/KykzaWCFGSU",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "rwIb2tlFOeC2PUWMtQg8",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "賢者タイムズ",
+    "description": "俺の名前はハルタカ、そんでもって写真のこっちは俺の彼女のユカ。自分で言うのも何だけど、結構美人だ。ユカは人が良くて生活力も高く、俺のことが大好きで最高の彼女だ。\n\n…でもまさか、あんなことになるなんて……\n\n約1年のアメリカ留学を終え、ついに日本に帰るときが来た。ユカのやつ、俺に会えるのを楽しみにしてるだろうなぁ〜\n空港につくと、そこにはわざわざ迎えに来てくれたユカの姿が、\n「ユカー！ただいま！」\n「おかえり！」\nしばらく我慢してた分、これからたくさんユカとの思い出を作るぞ！\n\nそう思っていた最中……\n\nあれぇ、ユカ、今日も忙しいのか……最近電話もあんまりできないなぁ……\n俺は持ち前のストーキング力でユカの裏垢を特定した。\nするとそこには何と！衝撃的なツイートの数々が！！！\n\n「帰国した彼氏肉団子になっててワロタww」\n「アメリカで何食べたらあんなに太れるんだよ笑」\n「正直豚は男として見れないなぁ〜」\n\nがーーーん！\n俺はあまりのショックにコンビニでファミチキを買って食べた。あぁ、アメリカの高カロリーなチキンレッグが恋しい……\nまあ、日本で食べてればすぐ痩せるだろう、ユカもすぐになれてくれるさ！さすがに小杉よりデブじゃないだろうし！！\n\nそして後日\n\n小杉「おーハルタカ！元気？」\nハルタカ「え…誰……って、小杉！！そんなに痩せてどうしたんだよ！！」\n小「はっはっはっ、実は最近ダイエットしたんだ！おかげでこのスリムボディを手に入れたってわけ！」\nハ「聞いてくれ…実はアメリカの食生活で太って彼女に振られそうなんだ……」\n小「なるほどな…確かに、日本人女性の約76%は太った男を異性として見れないというデータがあるからな！」\nハ「ガーン、やっぱり俺はもうだめなのか……」\n小「いや、諦めるのはまだ早いぜ！」\nハ「え？？」\n小「俺の痩せた秘訣を知りたいか？」\nハ「頼む！教えてくれ！！！」\n小「ジャーン！これが今密かに話題の、ブルーグラスダイエットだ！！！」\nハ「ブルーグラス…ダイエット？？」\n小「まだ日本ではそんなに流行ってないけど、海外ではすごい注目されてる、プロのアスリートも実践してるダイエット方なんだぜ！やり方は簡単、毎日楽器を練習するだけ！そうするだけでみるみる脂肪が落ちていくんだ！」\nハ「す、すごい！でも、なんで楽器を弾くだけで……」\n小「ハーバード大学の研究によると、実は楽器演奏は筋トレの約5倍の消費カロリーがあることが証明されているんだ！アメリカの国立衛生研究所も、楽器演奏が肥満解消に効果的であることを認めているんだぜ！」\nハ「マジか！早速始めよう！！でも…やっぱり楽器練習って出番がないとしんどいよなぁ……」\n小「そんなお前にこれ！」\nハ「…bluegrass lockdown music festival…？」\n小「そう、実はこれは今度オンラインで開催されるブルーグラスフェスなんだ！これを目標に頑張るってのはどうだ？」\nハ「…いいな！！見てろよユカ！俺は必ず痩せてみせるからなぁぁぁ！！！」",
+    "fileURLs": "",
+    "fileNames": [
+      "アップロード用完成版.mp4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "s7kNOLpV7jDWt1g4JMgE",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "The Unfamous Stringbusters",
+    "description": "東北大のOBバンド。The Infamous Stringdustersのカバーバンドとして2年ほど前から活動中。\nWashington DCで演奏されたBlack Rockの完全再現＋αに挑みました。",
+    "fileURLs": "https://youtu.be/fOkYIyVm1Bs",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "s8AzIm0bsAsVlFaVsLyQ",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "Master of Traditional Bluegrass",
+    "description": "MTB(Master of Traditional Bluegrass )を目指して活動を始めました！\n\nfd テイター(安田)\nbj もっつ\nmd アッキー\ngt 村田\n",
+    "fileURLs": "",
+    "fileNames": [
+      "試作.mp4"
+    ],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "sGdp35Z2ptwkLh2oGUGd",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "かみおか（おだ）",
+    "description": "こんばんは。北大ブルーグラスOBのおだです。前回のフェスではかみおかwithぴぐもんとしてデュエットで参加しましたが、今回は1人で2曲やります。前回のオンラインフェスは顔の見えない動画が多かったので、顔芸で勝負します！バンドの方は、仲が悪くなって解散した…とかじゃありません。むしろ結婚しました。お祝い投票求む！！！！！！！",
+    "fileURLs": "https://youtu.be/BG0jsPDhRqM",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "sed69abRbIFr8w5X8bY3",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "れいじーぴっかーず",
+    "description": "いつもお世話になっております。れいじーぴっかーずです。\n前回はライブの動画でしたので今回はリモートで演奏を重ねてみました。\nオリジナルのインスト曲で「五条別れ」といいます。\nドブロの池田が作曲しました。曲名は曲のモチーフを思いついた場所の地名から取りました。\n短いですが結構な難曲です。頑張って演奏しましたのでみなさんに聴いていただきたいです。\nどうぞよろしくお願いします。",
+    "fileURLs": "",
+    "fileNames": [
+      "20201219_BLMF_れいじーぴっかーず_五条別れ.mp4"
+    ],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "slTNZGTchaPKE3n69UPk",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "扇町ボンバーズ",
+    "description": "北海道札幌を中心に活動しているバンドです。\n年齢、出身地、出身校、仕事も全く異なる社会人6名が、それぞれの好みやこだわりをぶつけ合い試行錯誤の日々。\n\n今年、参加予定だった旭川ブルーグラスフェスティバルが中止になってしまったので、はじめての動画配信にチャレンジしてみました。\n不慣れなところも多々ありますが、楽しんでいただければ幸いです。\n\nこの動画は、札幌市文化芸術公演配信補助金「さっぽろアートライブ」という企画のために制作したもので、そちらの12曲フルバージョンは12月30日からYouTube上にて公開予定です。\n12月30日以降に「さっぽろアートライブ、扇町ボンバーズ」で検索して是非ご視聴ください。\n\n撮影場所：珈琲・軽食　ひいらぎ（札幌市中央区）\n会場の”ひいらぎ”は旭川ブルーグラスフェスティバルの主催・運営のお手伝いをしています。\n\n",
+    "fileURLs": "https://youtu.be/gzy_yLCGwCg",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "ssj6eEWbcSlO2AvW9Ezi",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "引きこもりジジイ",
+    "description": "相変わらず、今回も71歳の年寄りが、もたもた弾きます。\n「年寄りの冷や水」\n「名選手必ずしも名コーチならず」\n71歳のジジイが、断続的に半世紀やってきた「各種押弦楽器の左手の準備運動～初心者修錬法」の簡単な練習法と「Gランの各種変形」等を時間一杯、ぎっしり詰め込んで残しておきたいと参加します。\n長年楽器を弾いている方には、既によくご存じの方法もあるでしょう。でも、初心者には、手近な楽器であるギターを使い、左手に限っているので「ギター弾き」ならば簡単に想像がつき、容易にバンジョー、マンドリン等各種楽器への応用も想像できるはずです。\n\nなお、前回の「クロハンマーバンジョー入門から応用各種」の動画は、Youtubeに「多摩川童仙坊」で投稿しています。今回の動画も、近いうちにそちらに上げる予定です。",
+    "fileURLs": "",
+    "fileNames": [
+      "動画_提出用.wmv"
+    ],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "svmOCuzUYnMgl2hBykTn",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "マスダスインゴ",
+    "description": "昨年はビートルズメドレーでお邪魔しました還暦超え高校同窓Duoです。今回はユーミンメドレーです。ご存知の曲は口ずさみながら楽しんでいただければうれしいです。",
+    "fileURLs": "https://youtu.be/iQw_uRZxSz8",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "t45KCg7aCSSpXAVRt2Pi",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "もひかんクラウス＆もひかんステーション",
+    "description": "説明\n第1回は拝見。\n第2回は勇気を出してエントリ\n第3回は工房として協賛させていただく事になりました。\n腕も知識もございませんが、好きだけはずっと続けていたブルーグラス。\n前回のエントリーに際して沢山の皆さんから背中を押して頂き、ドブロも再び触ることになりました。\nそして今年も無事に、白塗り部門にエント\nリーできました。\nロックダウンフェス運営の皆さまをはじめ、工房のお客さま、 twitterのフォロワーの皆さま。あと米ちゃん。\n本当にありがとうございます\nこれから出会う皆さん。\nどうぞよろしくお願いします。\n動画の説明\n大好きなakusを演ってみました。公式MVをご存知の方なら、クスッと笑って頂けるかなと思います。\n深夜気温2度の河原でキャミソールは凍死するかと思いました。個人的に白塗りロンブロックが気に入ったので、これからもプライベートでやっていこうかなと思います。\n次回までにマンドリンを手に入れて、演奏できるバリエーションを増やせたらと思います。どこかに岩下マンドリン落ちてないかな。\n\n最後になりましたが、白塗りは敬愛表現です。アリソンクラウス＆ユニオンステーションは、私の大切な青春です。\n\n※今回も15分にははるか及ばない4分弱です。運営サイドのお手をわずらわせてばかりですが、どうぞ宜しくお願いします。",
+    "fileURLs": "https://youtu.be/46Tvy6h-WbU",
+    "fileNames": [],
+    "videoType": "crafted",
+    "individual": true
+  },
+  {
+    "id": "tUUIbE56ywaQmlcoAtr9",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "New East ",
+    "description": "1981年からほぼ同じメンバーでやってます。2019年12月26日　銀座ロッキートップでのライブから、Drifting Too Far From The Shore, Washington County, Helen, Blue Night の4曲です。",
+    "fileURLs": "https://youtu.be/3S8Vwgd-pAY",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "twOpNdodJsywfd4vIlzn",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "もやしちゃん",
+    "description": "ワールド製作担当のもやしです。\nArkansas Travelerをカンテレをメインにアレンジして弾いてみました。",
+    "fileURLs": "https://youtu.be/BgKiz0FmZbk",
+    "fileNames": [],
+    "videoType": "online",
+    "individual": null
+  },
+  {
+    "id": "twU9jyPyhmo5z27no4zx",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "StudioBABA&Masaki",
+    "description": "『『オンラインブルーグラスアワードとショート動画の両方の投稿となります。』』\n\n\nオンライン・ブルーグラス・アワード\nStudioBABA&Masaki\n今回のBluegrass Lockdown Music Festival Vol.4のために結成されたバンド\nれいじーぴっかーずの和泉眞生とその友達、馬場、正木での三人組でお届けします。\n本来は３曲やる予定でしたが3人の怠惰がそれを許さなかったので今回は一曲の投稿となります。\n評判が良ければ、次回に残りの２曲を完成させようと思うので皆様応援よろしくお願い致します。\n\nショート・ブルーグラス・アワード\nMao&Masaki\nStudioBABA&Masakiの撮影後のジャムで「高田渡の「アイスクリーム」ってショート動画にちょうど良くないですか？」という話になり急遽撮影。\n「もっとブルーグラス界で高田渡が流行って欲しい」「高田渡の「生活の柄」で一緒にジャムをしたい」「えーマジ？高田渡知らないの？キモーイ　高田渡知らないのは小学生までだよね？キャハハハハハハ（出典「奪！童貞。」）」っていう思いで演奏しました。よろしくお願いします。\n",
+    "fileURLs": "Youtube\nオンラインブルーグラスアワード\nhttps://youtu.be/ziI0de6Gcfw\n\nショート動画\nhttps://youtube.com/shorts/u7huHRlYXRY?feature=share\n\nGoogleドライブ（念の為）\nhttps://drive.google.com/drive/folders/1lJNlaK06R2SlV1kO7inwAdxEScJHhdn5?usp=sharing",
+    "fileNames": [],
+    "videoType": "mixed",
+    "individual": null
+  },
+  {
+    "id": "u7LflZfll2VEtrRHvzi0",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "原宿限界タピオカボーイズ without 米屋",
+    "description": "呼び込みくんのテーマを日曜日の深夜に急にみんなで合わせました 全員で７人いるのですが，動画には２人しか出てきません。多重録音は４人でやっています。米屋さんはコロナビールをかいにいってお休みです",
+    "fileURLs": "a",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "uDGLUffPSkpyIvTUVRy7",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "雑貨屋フレイヴァー",
+    "description": "ギターとマンドリンのデュオです。昨年11月末に仙台で行われたオールナイトヒラサワ2019というライブから３曲お届けします。",
+    "fileURLs": "https://youtu.be/2K06W6kIWdw",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "uOIUF9gFjPoEv5CcmP5P",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "あぶらげもやし",
+    "description": "バンジョーって和風な曲をしんみり演奏するのにも合いそうだよね！ということで、原神というゲームから和テーマのエリア「稲妻」の音楽をアレンジして演奏します。\n\nあぶらげ：バンジョー、ギター(2曲目)\nもやし：カンテレ、ギター(1曲目)、ミックス",
+    "fileURLs": "https://youtu.be/NY0QrDstNGw",
+    "fileNames": [
+      "aburagemoyashi.mp4"
+    ],
+    "videoType": "crafted",
+    "individual": null
+  },
+  {
+    "id": "uXIXS6QPzpD4nJLWBppE",
+    "eventId": "nWIe42DjxjQ4sircilRw",
+    "name": "H.MOMIYAMA",
+    "description": "心筋梗塞から復活して、リハビリを兼ねて録音したものです。",
+    "fileURLs": "",
+    "fileNames": [
+      "Nobody’s love is like mine .MOV"
+    ],
+    "videoType": "short",
+    "individual": null
+  },
+  {
+    "id": "uxlT1vkozDGUrxUa2ZtJ",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "日本アルプス弦楽団",
+    "description": "京都のヨーデル娘を筆頭にしたヨーデル好きによるヨーデル好きのためのヨーデルをするバンド。\n皆様のお部屋をアルプスの山々のように開放的な空間にできると嬉しいです！",
+    "fileURLs": "2分半の動画1本",
+    "fileNames": [
+      "IMG_9886.MP4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "vPR1kqeB9wMxvLkF6go3",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "日本アルプス弦楽団",
+    "description": "京都のヨーデル娘を筆頭にした、ヨーデル好きによるヨーデル好きのためのヨーデルをするバンド。\n楽しいヨーデルが皆さんを健康に導きます！",
+    "fileURLs": "https://youtu.be/Lx3J5Wnqkzg",
+    "fileNames": [],
+    "videoType": "mixed",
+    "individual": null
+  },
+  {
+    "id": "vdehXgTYyN9G7bXIrxcq",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "GMB48(仮)",
+    "description": "ゲームミュージックをブルーグラスアレンジで演奏しています。",
+    "fileURLs": "ヨッシーアイランドよりアスレチックのテーマ",
+    "fileNames": [
+      "IMG_0975.MP4"
+    ],
+    "videoType": null,
+    "individual": null
+  },
+  {
+    "id": "ww4X3UcdTxybjW0a09yo",
+    "eventId": "VTH7oiZR2vmMCPgcW8xC",
+    "name": "hanji",
+    "description": "40年以上前のブッチロビンスのアルバムの中の曲です。一緒にやる人いないので一人でやってみました。",
+    "fileURLs": "",
+    "fileNames": [
+      "スリッピンオンアイス.avi"
+    ],
+    "videoType": "crafted",
+    "individual": true
+  },
+  {
+    "id": "xdcEC7sjT12ZiuimXUXg",
+    "eventId": "fe2ypz0gnDuSiY1t2KjG",
+    "name": "鳩正宗",
+    "description": "2009年結成。神戸を中心に活動中。Traditionalな曲から色物まで、いろんな曲やってます！New Grass Revivalが多め。",
+    "fileURLs": "",
+    "fileNames": [
+      "鳩正宗1_Cold Sailor.mp4",
+      "鳩正宗2_Pathway of teardrop.mp4"
+    ],
+    "videoType": "live",
+    "individual": null
+  },
+  {
+    "id": "zpU6LSH8muIVRlaKzBBs",
+    "eventId": "2pbLysWMNdNXnSvgBNr2",
+    "name": "八ヶ岳マウンテンボーイズ",
+    "description": "ブルーグラスに初めて接する方にも魅力が伝わるよう、スピーディーな曲やメロディラインの美しい曲を中心に、ワンマイク・パフォーマンスにこだわった演奏を行っている。\n山梨県の八ヶ岳南麓エリアで活動をしており、練習の帰り道は時々Foggy Mountainと化す。\n\nメンバー\n岩下 ユタカ Md\n福沢 タケヲ Bj\n成澤 やすし Ba\n吉田 コーセイ Gt\n\n動画は昨年9月のライブのものです。",
+    "fileURLs": "https://youtu.be/ITbu1eMtiE8",
+    "fileNames": [],
+    "videoType": null,
+    "individual": null
+  }
+]

--- a/src/data/legacy/events.json
+++ b/src/data/legacy/events.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "2pbLysWMNdNXnSvgBNr2",
+    "volume": 1,
+    "year": 2020,
+    "title": "オンラインフェス"
+  },
+  {
+    "id": "fe2ypz0gnDuSiY1t2KjG",
+    "volume": 2,
+    "year": 2020,
+    "title": "Bluegrass Lockdown Music Festival Vol.2"
+  },
+  {
+    "id": "VTH7oiZR2vmMCPgcW8xC",
+    "volume": 3,
+    "year": 2021,
+    "title": "Bluegrass Lockdown Music Festival Vol.3"
+  },
+  {
+    "id": "nWIe42DjxjQ4sircilRw",
+    "volume": 4,
+    "year": 2022,
+    "title": "Bluegrass Lockdown Music Festival Vol.4"
+  }
+]

--- a/src/data/legacy/results.json
+++ b/src/data/legacy/results.json
@@ -1,0 +1,709 @@
+{
+  "2pbLysWMNdNXnSvgBNr2": {
+    "DMDEUdmPp8Mxu3TahIU8": {
+      "kinds": {},
+      "total": 6
+    },
+    "uDGLUffPSkpyIvTUVRy7": {
+      "kinds": {},
+      "total": 26
+    },
+    "nPyr6a1xpzrEoMOYiVVs": {
+      "kinds": {},
+      "total": 4
+    },
+    "IRKkyVrzPYoAbzef7udY": {
+      "kinds": {},
+      "total": 11
+    },
+    "gj485A0x7bjZzfG6ZL2b": {
+      "kinds": {},
+      "total": 16
+    },
+    "2cwUikHBbvgXTsQXHh4O": {
+      "kinds": {},
+      "total": 4
+    },
+    "u7LflZfll2VEtrRHvzi0": {
+      "kinds": {},
+      "total": 1
+    },
+    "rwIb2tlFOeC2PUWMtQg8": {
+      "kinds": {},
+      "total": 16
+    },
+    "jjuroEWrFNmuaJr39BNh": {
+      "kinds": {},
+      "total": 27
+    },
+    "uxlT1vkozDGUrxUa2ZtJ": {
+      "kinds": {},
+      "total": 6
+    },
+    "zpU6LSH8muIVRlaKzBBs": {
+      "kinds": {},
+      "total": 11
+    },
+    "QbPSsjzAsadU2aQVRDNs": {
+      "kinds": {},
+      "total": 6
+    },
+    "s7kNOLpV7jDWt1g4JMgE": {
+      "kinds": {},
+      "total": 25
+    },
+    "WBYj13bCP2p1Dm6A3OtT": {
+      "kinds": {},
+      "total": 4
+    },
+    "qYZMG26eovIhn9j217aV": {
+      "kinds": {},
+      "total": 11
+    },
+    "ZZZqW63G39tvaGdfrRQp": {
+      "kinds": {},
+      "total": 1
+    },
+    "vdehXgTYyN9G7bXIrxcq": {
+      "kinds": {},
+      "total": 3
+    },
+    "aeZxzoBE2AakMFhmjSbH": {
+      "kinds": {},
+      "total": 2
+    },
+    "CAbhqYZI7P7SrPg9Zjqu": {
+      "kinds": {},
+      "total": 4
+    },
+    "Xim7WGtgz3kvlKyWR4Tm": {
+      "kinds": {},
+      "total": 8
+    },
+    "ipyRjzqecWtP3thsyixV": {
+      "kinds": {},
+      "total": 5
+    },
+    "1HvlvZ1b0FcOtdCBhRVa": {
+      "kinds": {},
+      "total": 5
+    },
+    "hTZ79HtV8BYwSNsBlkpf": {
+      "kinds": {},
+      "total": 2
+    },
+    "IhcaTBwekXIluANHJo4B": {
+      "kinds": {},
+      "total": 1
+    },
+    "960A88dcNfBYjlHJJMy0": {
+      "kinds": {},
+      "total": 1
+    },
+    "tUUIbE56ywaQmlcoAtr9": {
+      "kinds": {},
+      "total": 1
+    },
+    "adXryDV5Ba58KFCflEmn": {
+      "kinds": {},
+      "total": 1
+    },
+    "NYmMaq4dSroiGMhLfNcU": {
+      "kinds": {},
+      "total": 2
+    },
+    "6w0dm06G3mFV53flK7xo": {
+      "kinds": {},
+      "total": 2
+    },
+    "jSyhnowRfbtQWx5F70Gh": {
+      "kinds": {},
+      "total": 1
+    }
+  },
+  "fe2ypz0gnDuSiY1t2KjG": {
+    "IOGyTrcOkyVftwUkNW9L": {
+      "kinds": {
+        "ライブ動画賞": 5,
+        "動画編集技術賞": 1,
+        "とにかく端的に好き": 4,
+        "演奏すごい賞": 1,
+        "音声技術賞": 1,
+        "独創独自賞": 1
+      },
+      "total": 13
+    },
+    "slTNZGTchaPKE3n69UPk": {
+      "kinds": {
+        "ブルーグラス愛を感じる賞": 7,
+        "心にしみた賞": 4,
+        "演奏すごい賞": 2,
+        "動画編集技術賞": 1,
+        "音声技術賞": 1
+      },
+      "total": 15
+    },
+    "CZuB8zzuntOlN8VHenDn": {
+      "kinds": {
+        "とにかく端的に好き": 4,
+        "ブルーグラス愛を感じる賞": 4,
+        "演奏すごい賞": 5
+      },
+      "total": 13
+    },
+    "KcauPkBqaeexSDYqMSyy": {
+      "kinds": {
+        "音声技術賞": 3,
+        "心にしみた賞": 4,
+        "演奏すごい賞": 12,
+        "ブルーグラス愛を感じる賞": 1,
+        "とにかく端的に好き": 6
+      },
+      "total": 26
+    },
+    "aj9EZuofNLKb1tZuHa30": {
+      "kinds": {
+        "心にしみた賞": 2,
+        "ブルーグラス愛を感じる賞": 3
+      },
+      "total": 5
+    },
+    "MMWYUDAtbNPw6Ugfmgpt": {
+      "kinds": {
+        "動画編集技術賞": 7,
+        "心にしみた賞": 9,
+        "とにかく端的に好き": 6,
+        "独創独自賞": 9,
+        "音声技術賞": 6,
+        "演奏すごい賞": 1,
+        "ブルーグラス愛を感じる賞": 1
+      },
+      "total": 39
+    },
+    "1tHV4N2NIYdYXDHkBNnv": {
+      "kinds": {
+        "音声技術賞": 3,
+        "動画編集技術賞": 7,
+        "独創独自賞": 2
+      },
+      "total": 12
+    },
+    "sed69abRbIFr8w5X8bY3": {
+      "kinds": {
+        "演奏すごい賞": 2,
+        "心にしみた賞": 3,
+        "ブルーグラス愛を感じる賞": 1,
+        "音声技術賞": 1
+      },
+      "total": 7
+    },
+    "LEYd0aUMCgZXboSQ0IeF": {
+      "kinds": {
+        "音声技術賞": 2,
+        "ブルーグラス愛を感じる賞": 1,
+        "動画編集技術賞": 1
+      },
+      "total": 4
+    },
+    "SOlp4sz006CxeLNzlMfn": {
+      "kinds": {
+        "ブルーグラス愛を感じる賞": 1,
+        "心にしみた賞": 1,
+        "独創独自賞": 2
+      },
+      "total": 4
+    },
+    "dNxTUIHFUKweBpOfWblH": {
+      "kinds": {
+        "動画編集技術賞": 11,
+        "とにかく端的に好き": 7,
+        "独創独自賞": 12,
+        "音声技術賞": 4,
+        "ブルーグラス愛を感じる賞": 1,
+        "心にしみた賞": 1
+      },
+      "total": 36
+    },
+    "PltjutVS2TUS0NLkxiv6": {
+      "kinds": {
+        "演奏すごい賞": 4,
+        "心にしみた賞": 4,
+        "音声技術賞": 3,
+        "ブルーグラス愛を感じる賞": 2
+      },
+      "total": 13
+    },
+    "OTcgLMwfT8LQMiVHN00Z": {
+      "kinds": {
+        "心にしみた賞": 6,
+        "独創独自賞": 1,
+        "演奏すごい賞": 1,
+        "とにかく端的に好き": 5,
+        "ブルーグラス愛を感じる賞": 2,
+        "音声技術賞": 1,
+        "動画編集技術賞": 1
+      },
+      "total": 17
+    },
+    "h5bp3jponsPdaDH9zu8p": {
+      "kinds": {
+        "とにかく端的に好き": 3,
+        "演奏すごい賞": 1,
+        "ブルーグラス愛を感じる賞": 1
+      },
+      "total": 5
+    },
+    "SE2hd8nSxiXvHhz84rVL": {
+      "kinds": {
+        "ライブ動画賞": 1,
+        "ブルーグラス愛を感じる賞": 1
+      },
+      "total": 2
+    },
+    "mardYDNcz6k3dsh1cBRh": {
+      "kinds": {
+        "とにかく端的に好き": 1,
+        "ライブ動画賞": 2
+      },
+      "total": 3
+    },
+    "ajLr7q2Mnsp5W44PZCtj": {
+      "kinds": {
+        "ブルーグラス愛を感じる賞": 1
+      },
+      "total": 1
+    },
+    "s8AzIm0bsAsVlFaVsLyQ": {
+      "kinds": {
+        "心にしみた賞": 2,
+        "ブルーグラス愛を感じる賞": 5,
+        "音声技術賞": 1,
+        "独創独自賞": 1,
+        "演奏すごい賞": 2
+      },
+      "total": 11
+    },
+    "BKHc0NTwSzP5U0DFIXz1": {
+      "kinds": {
+        "ライブ動画賞": 1
+      },
+      "total": 1
+    },
+    "UE3l1iIBSx04dO55O7Il": {
+      "kinds": {
+        "音声技術賞": 6,
+        "独創独自賞": 1
+      },
+      "total": 7
+    },
+    "3WyGKxbBwsdPr98tdrYt": {
+      "kinds": {
+        "独創独自賞": 1
+      },
+      "total": 1
+    },
+    "j6golAxQpsvYWSNdplsr": {
+      "kinds": {
+        "ブルーグラス愛を感じる賞": 5,
+        "ライブ動画賞": 3
+      },
+      "total": 8
+    },
+    "xdcEC7sjT12ZiuimXUXg": {
+      "kinds": {
+        "とにかく端的に好き": 2,
+        "ライブ動画賞": 4,
+        "動画編集技術賞": 1,
+        "独創独自賞": 1,
+        "演奏すごい賞": 2,
+        "ブルーグラス愛を感じる賞": 1,
+        "音声技術賞": 1,
+        "心にしみた賞": 1
+      },
+      "total": 13
+    },
+    "b4CeAZa34JgSnIWOHM5t": {
+      "kinds": {
+        "ライブ動画賞": 2,
+        "独創独自賞": 1
+      },
+      "total": 3
+    },
+    "sGdp35Z2ptwkLh2oGUGd": {
+      "kinds": {
+        "心にしみた賞": 2,
+        "独創独自賞": 1,
+        "演奏すごい賞": 2,
+        "音声技術賞": 1
+      },
+      "total": 6
+    },
+    "N7D2PFyi98GejHo01RGN": {
+      "kinds": {
+        "演奏すごい賞": 2,
+        "心にしみた賞": 1,
+        "ブルーグラス愛を感じる賞": 1
+      },
+      "total": 4
+    },
+    "SDwkZJMmGa1HW1M1u9Rv": {
+      "kinds": {
+        "演奏すごい賞": 3,
+        "音声技術賞": 1
+      },
+      "total": 4
+    },
+    "2yTLiVZTDNmPwIZuHPCO": {
+      "kinds": {
+        "独創独自賞": 1,
+        "心にしみた賞": 2,
+        "とにかく端的に好き": 2,
+        "ブルーグラス愛を感じる賞": 1
+      },
+      "total": 6
+    },
+    "pVqfeRg8lbJQowz24pD2": {
+      "kinds": {
+        "心にしみた賞": 3,
+        "音声技術賞": 1
+      },
+      "total": 4
+    },
+    "4PX2FlBsmFzC6kDK6O6U": {
+      "kinds": {
+        "心にしみた賞": 1
+      },
+      "total": 1
+    }
+  },
+  "VTH7oiZR2vmMCPgcW8xC": {
+    "8uGZK0Vg3woSrjbzUc0W": {
+      "kinds": {
+        "独創独自的で好き": 1,
+        "個人作品賞": 6,
+        "動画作品として好き": 6,
+        "心にしみた": 1,
+        "音楽作品として好き": 1
+      },
+      "total": 15
+    },
+    "DwOU4dbdFZeKKBs3Rh3o": {
+      "kinds": {
+        "とにかく好き": 12,
+        "心にしみた": 9,
+        "音楽作品として好き": 8,
+        "ベストバンドと思う!": 18,
+        "ブルーグラス愛を感じた": 4,
+        "動画作品として好き": 3
+      },
+      "total": 54
+    },
+    "9U4jBdwW7V66iqIhxCQk": {
+      "kinds": {
+        "ベストバンドと思う!": 9,
+        "心にしみた": 3,
+        "動画作品として好き": 4,
+        "音楽作品として好き": 5,
+        "とにかく好き": 3,
+        "ブルーグラス愛を感じた": 3,
+        "独創独自的で好き": 2
+      },
+      "total": 29
+    },
+    "o7LuAlWNG7OUFaLyo0KE": {
+      "kinds": {
+        "動画作品として好き": 4,
+        "ベストバンドと思う!": 2,
+        "心にしみた": 2,
+        "ブルーグラス愛を感じた": 3
+      },
+      "total": 11
+    },
+    "Wq3zNPe4b4VaFAbamrEW": {
+      "kinds": {
+        "個人作品賞": 10,
+        "心にしみた": 3,
+        "音楽作品として好き": 8,
+        "とにかく好き": 3,
+        "ブルーグラス愛を感じた": 1,
+        "独創独自的で好き": 5
+      },
+      "total": 30
+    },
+    "hdC7w49jP4VMXSHdX7WS": {
+      "kinds": {
+        "ブルーグラス愛を感じた": 4,
+        "心にしみた": 1
+      },
+      "total": 5
+    },
+    "ww4X3UcdTxybjW0a09yo": {
+      "kinds": {
+        "ブルーグラス愛を感じた": 1,
+        "心にしみた": 1
+      },
+      "total": 2
+    },
+    "T5u178K0dw8wXdUTU5oU": {
+      "kinds": {
+        "独創独自的で好き": 2,
+        "動画作品として好き": 1
+      },
+      "total": 3
+    },
+    "BqIikJSykcxSvdESYFHL": {
+      "kinds": {
+        "とにかく好き": 3,
+        "独創独自的で好き": 6,
+        "動画作品として好き": 3,
+        "音楽作品として好き": 1
+      },
+      "total": 13
+    },
+    "HHVglTF1335QVkxvb7PF": {
+      "kinds": {
+        "ブルーグラス愛を感じた": 8,
+        "ベストバンドと思う!": 3
+      },
+      "total": 11
+    },
+    "WoBFIInL5baLfqFv7bij": {
+      "kinds": {
+        "音楽作品として好き": 1
+      },
+      "total": 1
+    },
+    "35swQJlOdgbl1NkZqOYz": {
+      "kinds": {
+        "個人作品賞": 1,
+        "心にしみた": 2,
+        "ブルーグラス愛を感じた": 2,
+        "とにかく好き": 1
+      },
+      "total": 6
+    },
+    "4kRBVUYYPO6UyLG2lWS3": {
+      "kinds": {
+        "動画作品として好き": 6,
+        "独創独自的で好き": 9,
+        "ブルーグラス愛を感じた": 5,
+        "とにかく好き": 2,
+        "音楽作品として好き": 1
+      },
+      "total": 23
+    },
+    "vPR1kqeB9wMxvLkF6go3": {
+      "kinds": {
+        "独創独自的で好き": 1,
+        "ベストバンドと思う!": 2,
+        "ブルーグラス愛を感じた": 1,
+        "動画作品として好き": 2,
+        "とにかく好き": 2,
+        "心にしみた": 1
+      },
+      "total": 9
+    },
+    "cajLYmAzjVQwaU7aQFlw": {
+      "kinds": {
+        "音楽作品として好き": 2,
+        "独創独自的で好き": 2,
+        "動画作品として好き": 1,
+        "個人作品賞": 2
+      },
+      "total": 7
+    },
+    "VAwpVt4j0FlXVUdDyuAz": {
+      "kinds": {
+        "ブルーグラス愛を感じた": 1
+      },
+      "total": 1
+    },
+    "PqEK5LjNPZPyMJputeQ3": {
+      "kinds": {
+        "動画作品として好き": 2,
+        "個人作品賞": 5,
+        "音楽作品として好き": 1
+      },
+      "total": 8
+    },
+    "Re4ZMBXn8zybhRbusDPq": {
+      "kinds": {
+        "とにかく好き": 4,
+        "心にしみた": 2
+      },
+      "total": 6
+    },
+    "O4uFGgf5oWP2XvT5AgE4": {
+      "kinds": {
+        "独創独自的で好き": 2,
+        "とにかく好き": 4,
+        "音楽作品として好き": 3,
+        "動画作品として好き": 1
+      },
+      "total": 10
+    },
+    "svmOCuzUYnMgl2hBykTn": {
+      "kinds": {
+        "音楽作品として好き": 4,
+        "心にしみた": 7,
+        "とにかく好き": 2,
+        "ブルーグラス愛を感じた": 1
+      },
+      "total": 14
+    },
+    "uOIUF9gFjPoEv5CcmP5P": {
+      "kinds": {
+        "心にしみた": 2,
+        "独創独自的で好き": 1,
+        "とにかく好き": 1,
+        "音楽作品として好き": 1
+      },
+      "total": 5
+    },
+    "t45KCg7aCSSpXAVRt2Pi": {
+      "kinds": {
+        "独創独自的で好き": 3,
+        "個人作品賞": 2,
+        "動画作品として好き": 2,
+        "ブルーグラス愛を感じた": 1
+      },
+      "total": 8
+    },
+    "alZ4uc824NdPJWlse0yX": {
+      "kinds": {
+        "音楽作品として好き": 1
+      },
+      "total": 1
+    },
+    "fACvkZ3xDfLjCmcd6yP1": {
+      "kinds": {
+        "心にしみた": 1,
+        "独創独自的で好き": 1,
+        "とにかく好き": 1
+      },
+      "total": 3
+    },
+    "782GjIs7BFaEbtM4lsnM": {
+      "kinds": {
+        "個人作品賞": 3
+      },
+      "total": 3
+    },
+    "AfGw6sgQDxVbUACgWtCB": {
+      "kinds": {
+        "ブルーグラス愛を感じた": 1
+      },
+      "total": 1
+    }
+  },
+  "nWIe42DjxjQ4sircilRw": {
+    "8WdUkk1tpBBMdXkQVKP4": {
+      "kinds": {
+        "オンラインブルーグラスアワード": 6
+      },
+      "total": 6
+    },
+    "jQO6Vt7XMFzHo1Wa8aUy": {
+      "kinds": {
+        "オンラインブルーグラスアワード": 8
+      },
+      "total": 8
+    },
+    "9c2y6fz1txUVuuyjjDYt": {
+      "kinds": {
+        "ショートブルーグラスアワード": 4
+      },
+      "total": 4
+    },
+    "Ul41ZrFYemqp85T7BPHb": {
+      "kinds": {
+        "オフラインブルーグラスアワード": 8
+      },
+      "total": 8
+    },
+    "ZjTqZSF8v6ibKC9BLNvf": {
+      "kinds": {
+        "オンラインブルーグラスアワード": 1
+      },
+      "total": 1
+    },
+    "2lITA6shVJoACheeNg80": {
+      "kinds": {
+        "ショートブルーグラスアワード": 6
+      },
+      "total": 6
+    },
+    "FJ80qEthusSfDtf3kKyL": {
+      "kinds": {
+        "ショートブルーグラスアワード": 5
+      },
+      "total": 5
+    },
+    "Z2kTfP53OAu0mBEvCBOC": {
+      "kinds": {
+        "オフラインブルーグラスアワード": 8
+      },
+      "total": 8
+    },
+    "knpmWzgEfVNGpNlC1j8y": {
+      "kinds": {
+        "オンラインブルーグラスアワード": 3
+      },
+      "total": 3
+    },
+    "P5IceGASZKgcOd8ioEDj": {
+      "kinds": {
+        "オフラインブルーグラスアワード": 5
+      },
+      "total": 5
+    },
+    "twU9jyPyhmo5z27no4zx": {
+      "kinds": {
+        "ショートブルーグラスアワード": 1
+      },
+      "total": 1
+    },
+    "4RMWA1rONUjNgdKaRMVg": {
+      "kinds": {
+        "オンラインブルーグラスアワード": 3
+      },
+      "total": 3
+    },
+    "uXIXS6QPzpD4nJLWBppE": {
+      "kinds": {
+        "ショートブルーグラスアワード": 5
+      },
+      "total": 5
+    },
+    "gLRbyuKUvJDKRXmsn3Pj": {
+      "kinds": {
+        "オンラインブルーグラスアワード": 1
+      },
+      "total": 1
+    },
+    "ZR4QzjmHlE5KUDHpNVdZ": {
+      "kinds": {
+        "オンラインブルーグラスアワード": 1
+      },
+      "total": 1
+    },
+    "kXnMhFzCGMVwHQheTZFq": {
+      "kinds": {
+        "オンラインブルーグラスアワード": 1
+      },
+      "total": 1
+    },
+    "Sd1rXqWwV2pLiAotf15r": {
+      "kinds": {
+        "オフラインブルーグラスアワード": 1
+      },
+      "total": 1
+    },
+    "bd4isAFeOG1KpzKFUDgK": {
+      "kinds": {
+        "オンラインブルーグラスアワード": 1
+      },
+      "total": 1
+    }
+  }
+}

--- a/src/data/legacy/summary.json
+++ b/src/data/legacy/summary.json
@@ -1,0 +1,41 @@
+{
+  "exportedAt": "2026-08-06T09:37:27.027Z",
+  "source": "Firestore REST API (https://firestore.googleapis.com/v1/projects/bluemoon-82c0b/databases/(default)/documents)",
+  "entriesTotal": 121,
+  "entriesConsented": 115,
+  "votesTotal": 168,
+  "events": [
+    {
+      "id": "2pbLysWMNdNXnSvgBNr2",
+      "volume": 1,
+      "year": 2020,
+      "title": "オンラインフェス",
+      "entries": 31,
+      "votesCast": 213
+    },
+    {
+      "id": "fe2ypz0gnDuSiY1t2KjG",
+      "volume": 2,
+      "year": 2020,
+      "title": "Bluegrass Lockdown Music Festival Vol.2",
+      "entries": 30,
+      "votesCast": 284
+    },
+    {
+      "id": "VTH7oiZR2vmMCPgcW8xC",
+      "volume": 3,
+      "year": 2021,
+      "title": "Bluegrass Lockdown Music Festival Vol.3",
+      "entries": 28,
+      "votesCast": 279
+    },
+    {
+      "id": "nWIe42DjxjQ4sircilRw",
+      "volume": 4,
+      "year": 2022,
+      "title": "Bluegrass Lockdown Music Festival Vol.4",
+      "entries": 26,
+      "votesCast": 68
+    }
+  ]
+}

--- a/src/data/legacy/votes.json
+++ b/src/data/legacy/votes.json
@@ -1,0 +1,1883 @@
+[
+  {
+    "id": "047aIGvHo2T0BnK7MSGOusfIxV62",
+    "createdAt": "2020-12-20T02:03:00.618Z",
+    "entryKinds": {
+      "ライブ動画賞": "IOGyTrcOkyVftwUkNW9L",
+      "ブルーグラス愛を感じる賞": "slTNZGTchaPKE3n69UPk",
+      "とにかく端的に好き": "CZuB8zzuntOlN8VHenDn",
+      "音声技術賞": "KcauPkBqaeexSDYqMSyy",
+      "心にしみた賞": "aj9EZuofNLKb1tZuHa30"
+    }
+  },
+  {
+    "id": "1WYIFG1QXtPDN1flNMPc2zKDNRL2",
+    "createdAt": "2020-12-20T03:56:06.852Z",
+    "entryKinds": {
+      "心にしみた賞": "KcauPkBqaeexSDYqMSyy"
+    }
+  },
+  {
+    "id": "1ekeclx7QrboCOpnuO9K1UUit0B3",
+    "createdAt": null,
+    "entryIds": [
+      "DMDEUdmPp8Mxu3TahIU8",
+      "uDGLUffPSkpyIvTUVRy7",
+      "nPyr6a1xpzrEoMOYiVVs"
+    ]
+  },
+  {
+    "id": "1updHI11kwSH3JJxdzAdVkRYIa83",
+    "createdAt": "2020-12-20T05:29:00.868Z",
+    "entryKinds": {
+      "動画編集技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "心にしみた賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "音声技術賞": "1tHV4N2NIYdYXDHkBNnv",
+      "とにかく端的に好き": "MMWYUDAtbNPw6Ugfmgpt",
+      "ブルーグラス愛を感じる賞": "CZuB8zzuntOlN8VHenDn",
+      "独創独自賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "演奏すごい賞": "sed69abRbIFr8w5X8bY3"
+    }
+  },
+  {
+    "id": "2IUisDqiDWX0l7XfOBVXVDhV8sA2",
+    "createdAt": null,
+    "entryIds": [
+      "IRKkyVrzPYoAbzef7udY",
+      "gj485A0x7bjZzfG6ZL2b",
+      "2cwUikHBbvgXTsQXHh4O"
+    ]
+  },
+  {
+    "id": "2szzBQBjeKZ07LBiCBaGFN8g97q2",
+    "createdAt": "2023-01-30T11:46:52.274Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "8WdUkk1tpBBMdXkQVKP4"
+    }
+  },
+  {
+    "id": "2vJ4DJizKyQJQBb6dE7OIErnF2z1",
+    "createdAt": null,
+    "entryIds": [
+      "u7LflZfll2VEtrRHvzi0",
+      "rwIb2tlFOeC2PUWMtQg8",
+      "gj485A0x7bjZzfG6ZL2b"
+    ]
+  },
+  {
+    "id": "4DEuQ4CRe5OjvRJpBfRp1pIh0HM2",
+    "createdAt": "2020-12-20T06:37:40.480Z",
+    "entryKinds": {
+      "独創独自的で好き": "8uGZK0Vg3woSrjbzUc0W",
+      "音声技術賞": "LEYd0aUMCgZXboSQ0IeF",
+      "ブルーグラス愛を感じる賞": "SOlp4sz006CxeLNzlMfn",
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ベストバンドと思う!": "9U4jBdwW7V66iqIhxCQk",
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH",
+      "動画作品として好き": "o7LuAlWNG7OUFaLyo0KE",
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW",
+      "とにかく端的に好き": "dNxTUIHFUKweBpOfWblH",
+      "心にしみた": "DwOU4dbdFZeKKBs3Rh3o",
+      "音楽作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "心にしみた賞": "SOlp4sz006CxeLNzlMfn",
+      "ブルーグラス愛を感じた": "hdC7w49jP4VMXSHdX7WS",
+      "演奏すごい賞": "PltjutVS2TUS0NLkxiv6",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH"
+    }
+  },
+  {
+    "id": "4Feg45yQPbMFaUklR3vjnIj1T5j2",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "uxlT1vkozDGUrxUa2ZtJ"
+    ]
+  },
+  {
+    "id": "4R8ESjIq3PaMrSlodwg78RKW11v1",
+    "createdAt": "2021-12-31T08:40:36.260Z",
+    "entryKinds": {
+      "心にしみた": "Wq3zNPe4b4VaFAbamrEW",
+      "ブルーグラス愛を感じた": "ww4X3UcdTxybjW0a09yo",
+      "個人作品賞": "8uGZK0Vg3woSrjbzUc0W",
+      "独創独自的で好き": "T5u178K0dw8wXdUTU5oU",
+      "動画作品として好き": "o7LuAlWNG7OUFaLyo0KE",
+      "音楽作品として好き": "Wq3zNPe4b4VaFAbamrEW",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "とにかく好き": "BqIikJSykcxSvdESYFHL"
+    }
+  },
+  {
+    "id": "4ugEAxiAuhbTTJTrkBSp4vvmhPF3",
+    "createdAt": null,
+    "entryIds": [
+      "zpU6LSH8muIVRlaKzBBs",
+      "jjuroEWrFNmuaJr39BNh",
+      "rwIb2tlFOeC2PUWMtQg8"
+    ]
+  },
+  {
+    "id": "5KlG91TQjjT6mrVdMieDer3nxpD3",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh"
+    ]
+  },
+  {
+    "id": "5ScI5P1TTJOpdne37k8C1MpzwFn2",
+    "createdAt": null,
+    "entryIds": [
+      "QbPSsjzAsadU2aQVRDNs",
+      "s7kNOLpV7jDWt1g4JMgE",
+      "zpU6LSH8muIVRlaKzBBs"
+    ]
+  },
+  {
+    "id": "6RkWOJG5QzgIOiUZSoHcxNqfu653",
+    "createdAt": "2020-12-21T04:45:20.531Z",
+    "entryKinds": {
+      "独創独自賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "演奏すごい賞": "CZuB8zzuntOlN8VHenDn",
+      "ブルーグラス愛を感じた": "HHVglTF1335QVkxvb7PF",
+      "心にしみた賞": "OTcgLMwfT8LQMiVHN00Z",
+      "音楽作品として好き": "WoBFIInL5baLfqFv7bij",
+      "オンラインブルーグラスアワード": "jQO6Vt7XMFzHo1Wa8aUy",
+      "心にしみた": "9U4jBdwW7V66iqIhxCQk",
+      "とにかく端的に好き": "h5bp3jponsPdaDH9zu8p",
+      "個人作品賞": "35swQJlOdgbl1NkZqOYz",
+      "動画作品として好き": "4kRBVUYYPO6UyLG2lWS3",
+      "ショートブルーグラスアワード": "9c2y6fz1txUVuuyjjDYt",
+      "ベストバンドと思う!": "o7LuAlWNG7OUFaLyo0KE",
+      "動画編集技術賞": "sMQUG68mLn4MRytUzPa7",
+      "とにかく好き": "BqIikJSykcxSvdESYFHL",
+      "オフラインブルーグラスアワード": "Ul41ZrFYemqp85T7BPHb",
+      "ブルーグラス愛を感じる賞": "slTNZGTchaPKE3n69UPk",
+      "音声技術賞": "dNxTUIHFUKweBpOfWblH",
+      "独創独自的で好き": "vPR1kqeB9wMxvLkF6go3"
+    }
+  },
+  {
+    "id": "6eKh5PCKgueoM1hM43lbNDa1WUo1",
+    "createdAt": "2020-12-20T02:28:49.502Z",
+    "entryKinds": {
+      "ライブ動画賞": "SE2hd8nSxiXvHhz84rVL",
+      "音楽作品として好き": "cajLYmAzjVQwaU7aQFlw",
+      "ブルーグラス愛を感じた": "VAwpVt4j0FlXVUdDyuAz",
+      "独創独自賞": "OTcgLMwfT8LQMiVHN00Z",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "心にしみた賞": "aj9EZuofNLKb1tZuHa30",
+      "動画作品として好き": "PqEK5LjNPZPyMJputeQ3",
+      "とにかく端的に好き": "mardYDNcz6k3dsh1cBRh",
+      "心にしみた": "o7LuAlWNG7OUFaLyo0KE",
+      "オンラインブルーグラスアワード": "ZjTqZSF8v6ibKC9BLNvf",
+      "とにかく好き": "Re4ZMBXn8zybhRbusDPq",
+      "ベストバンドと思う!": "9U4jBdwW7V66iqIhxCQk",
+      "動画編集技術賞": "1tHV4N2NIYdYXDHkBNnv",
+      "ブルーグラス愛を感じる賞": "ajLr7q2Mnsp5W44PZCtj",
+      "独創独自的で好き": "O4uFGgf5oWP2XvT5AgE4",
+      "音声技術賞": "bLTqDpa2L6iRzP02dnOO"
+    }
+  },
+  {
+    "id": "6r5kefRRTxTterEnp1pfTVY7Mwu2",
+    "createdAt": null,
+    "entryIds": [
+      "QbPSsjzAsadU2aQVRDNs",
+      "WBYj13bCP2p1Dm6A3OtT",
+      "uDGLUffPSkpyIvTUVRy7"
+    ]
+  },
+  {
+    "id": "6uDSwgfQ9KhnWB1LkGq8Q2Ejgo73",
+    "createdAt": "2020-12-20T01:58:37.064Z",
+    "entryKinds": {
+      "心にしみた賞": "s8AzIm0bsAsVlFaVsLyQ",
+      "ブルーグラス愛を感じた": "HHVglTF1335QVkxvb7PF",
+      "独創独自賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "演奏すごい賞": "OTcgLMwfT8LQMiVHN00Z",
+      "音楽作品として好き": "svmOCuzUYnMgl2hBykTn",
+      "ライブ動画賞": "BKHc0NTwSzP5U0DFIXz1",
+      "とにかく端的に好き": "MMWYUDAtbNPw6Ugfmgpt",
+      "心にしみた": "35swQJlOdgbl1NkZqOYz",
+      "動画作品として好き": "8uGZK0Vg3woSrjbzUc0W",
+      "動画編集技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "とにかく好き": "Wq3zNPe4b4VaFAbamrEW",
+      "独創独自的で好き": "4kRBVUYYPO6UyLG2lWS3",
+      "音声技術賞": "UE3l1iIBSx04dO55O7Il",
+      "ブルーグラス愛を感じる賞": "bJHGuI5kZ9v7S83oc5KI"
+    }
+  },
+  {
+    "id": "7DUw8s6LslT2DfK4eKMeGMFLW6H2",
+    "createdAt": "2020-12-20T05:27:23.817Z",
+    "entryKinds": {
+      "独創独自賞": "3WyGKxbBwsdPr98tdrYt",
+      "ブルーグラス愛を感じる賞": "j6golAxQpsvYWSNdplsr",
+      "とにかく端的に好き": "xdcEC7sjT12ZiuimXUXg",
+      "心にしみた賞": "OTcgLMwfT8LQMiVHN00Z",
+      "動画編集技術賞": "1tHV4N2NIYdYXDHkBNnv"
+    }
+  },
+  {
+    "id": "7Q5PmxDed8UHxhrj1G6oQ9lvuRN2",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "qYZMG26eovIhn9j217aV",
+      "gj485A0x7bjZzfG6ZL2b"
+    ]
+  },
+  {
+    "id": "7vokXoRS5ZdkAAZ98DdbeMk8b032",
+    "createdAt": "2020-12-22T01:39:54.340Z",
+    "entryKinds": {
+      "音声技術賞": "UE3l1iIBSx04dO55O7Il",
+      "独創独自的で好き": "BqIikJSykcxSvdESYFHL",
+      "ブルーグラス愛を感じる賞": "slTNZGTchaPKE3n69UPk",
+      "ベストバンドと思う!": "vPR1kqeB9wMxvLkF6go3",
+      "動画編集技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "とにかく好き": "O4uFGgf5oWP2XvT5AgE4",
+      "動画作品として好き": "8uGZK0Vg3woSrjbzUc0W",
+      "個人作品賞": "8uGZK0Vg3woSrjbzUc0W",
+      "心にしみた": "uOIUF9gFjPoEv5CcmP5P",
+      "とにかく端的に好き": "dNxTUIHFUKweBpOfWblH",
+      "音楽作品として好き": "Wq3zNPe4b4VaFAbamrEW",
+      "ライブ動画賞": "b4CeAZa34JgSnIWOHM5t",
+      "心にしみた賞": "slTNZGTchaPKE3n69UPk",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "ブルーグラス愛を感じた": "DwOU4dbdFZeKKBs3Rh3o"
+    }
+  },
+  {
+    "id": "89uEXewIpYNHvY2Y6EzTe8MEYLG3",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "uxlT1vkozDGUrxUa2ZtJ",
+      "rwIb2tlFOeC2PUWMtQg8"
+    ]
+  },
+  {
+    "id": "9OxUbixjH0NhepFvA2ZImgrNfAB3",
+    "createdAt": "2020-12-21T05:48:37.018Z",
+    "entryKinds": {
+      "ショートブルーグラスアワード": "2lITA6shVJoACheeNg80",
+      "とにかく好き": "Re4ZMBXn8zybhRbusDPq",
+      "ベストバンドと思う!": "vPR1kqeB9wMxvLkF6go3",
+      "動画編集技術賞": "1tHV4N2NIYdYXDHkBNnv",
+      "ブルーグラス愛を感じる賞": "s8AzIm0bsAsVlFaVsLyQ",
+      "オフラインブルーグラスアワード": "Ul41ZrFYemqp85T7BPHb",
+      "独創独自的で好き": "cajLYmAzjVQwaU7aQFlw",
+      "音声技術賞": "UE3l1iIBSx04dO55O7Il",
+      "ブルーグラス愛を感じた": "Wq3zNPe4b4VaFAbamrEW",
+      "独創独自賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "心にしみた賞": "PltjutVS2TUS0NLkxiv6",
+      "ライブ動画賞": "b4CeAZa34JgSnIWOHM5t",
+      "音楽作品として好き": "Wq3zNPe4b4VaFAbamrEW",
+      "とにかく端的に好き": "CZuB8zzuntOlN8VHenDn",
+      "心にしみた": "Wq3zNPe4b4VaFAbamrEW",
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW",
+      "動画作品として好き": "4kRBVUYYPO6UyLG2lWS3"
+    }
+  },
+  {
+    "id": "9WkWLc4RU5frQvcQtnv8QJOMC6u2",
+    "createdAt": "2020-12-20T03:24:11.251Z",
+    "entryKinds": {
+      "動画編集技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ライブ動画賞": "mardYDNcz6k3dsh1cBRh",
+      "心にしみた賞": "sGdp35Z2ptwkLh2oGUGd",
+      "音声技術賞": "PltjutVS2TUS0NLkxiv6",
+      "とにかく端的に好き": "sMQUG68mLn4MRytUzPa7",
+      "ブルーグラス愛を感じる賞": "s8AzIm0bsAsVlFaVsLyQ",
+      "演奏すごい賞": "slTNZGTchaPKE3n69UPk",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH"
+    }
+  },
+  {
+    "id": "9eOcPbFRJKSIf45JlJ0pD1GFoOQ2",
+    "createdAt": "2020-12-20T11:16:42.120Z",
+    "entryKinds": {
+      "ライブ動画賞": "j6golAxQpsvYWSNdplsr",
+      "動画編集技術賞": "sMQUG68mLn4MRytUzPa7",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "演奏すごい賞": "N7D2PFyi98GejHo01RGN",
+      "とにかく端的に好き": "CZuB8zzuntOlN8VHenDn",
+      "ブルーグラス愛を感じる賞": "KcauPkBqaeexSDYqMSyy",
+      "音声技術賞": "s8AzIm0bsAsVlFaVsLyQ",
+      "心にしみた賞": "slTNZGTchaPKE3n69UPk"
+    }
+  },
+  {
+    "id": "ALWmkaJxBWVWHHxg7FsOKhuyrmy1",
+    "createdAt": "2020-12-20T04:35:16.418Z",
+    "entryKinds": {
+      "演奏すごい賞": "SDwkZJMmGa1HW1M1u9Rv",
+      "とにかく端的に好き": "CZuB8zzuntOlN8VHenDn",
+      "音声技術賞": "KcauPkBqaeexSDYqMSyy",
+      "心にしみた賞": "slTNZGTchaPKE3n69UPk"
+    }
+  },
+  {
+    "id": "BPsVvaNAVObcG9wrGy2im4XQXd32",
+    "createdAt": "2020-12-20T09:19:27.306Z",
+    "entryKinds": {
+      "動画編集技術賞": "sMQUG68mLn4MRytUzPa7",
+      "独創独自賞": "sMQUG68mLn4MRytUzPa7",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "とにかく端的に好き": "OTcgLMwfT8LQMiVHN00Z",
+      "ブルーグラス愛を感じる賞": "sMQUG68mLn4MRytUzPa7",
+      "音声技術賞": "sMQUG68mLn4MRytUzPa7",
+      "心にしみた賞": "sMQUG68mLn4MRytUzPa7"
+    }
+  },
+  {
+    "id": "BZqDxTVFcidZJ7yeAirXxtyt8N72",
+    "createdAt": "2023-01-30T11:49:01.328Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "8WdUkk1tpBBMdXkQVKP4",
+      "ショートブルーグラスアワード": "FJ80qEthusSfDtf3kKyL",
+      "オフラインブルーグラスアワード": "Z2kTfP53OAu0mBEvCBOC"
+    }
+  },
+  {
+    "id": "BmJoKTQOzEgKrQ2lo3G7sJfCWYw2",
+    "createdAt": "2023-01-29T04:11:29.676Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "knpmWzgEfVNGpNlC1j8y"
+    }
+  },
+  {
+    "id": "EVFlZVPgtaf3BqWs5ul48RaE7uY2",
+    "createdAt": null
+  },
+  {
+    "id": "EvwEPGuH4MOdoUMs1LHlSk7ROfG2",
+    "createdAt": null,
+    "entryIds": [
+      "gj485A0x7bjZzfG6ZL2b",
+      "ZZZqW63G39tvaGdfrRQp",
+      "jjuroEWrFNmuaJr39BNh"
+    ]
+  },
+  {
+    "id": "FuoerBQe6rQTqcG2bASjv7wruAx2",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "jjuroEWrFNmuaJr39BNh",
+      "gj485A0x7bjZzfG6ZL2b"
+    ]
+  },
+  {
+    "id": "G5dM3YojDUdruB4NqZ8RwIjYeK62",
+    "createdAt": "2021-12-30T07:03:20.376Z",
+    "entryKinds": {
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "音楽作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "独創独自的で好き": "4kRBVUYYPO6UyLG2lWS3",
+      "心にしみた": "DwOU4dbdFZeKKBs3Rh3o",
+      "ブルーグラス愛を感じた": "DwOU4dbdFZeKKBs3Rh3o"
+    }
+  },
+  {
+    "id": "Gb5yxX7Un0ZB5aRXYd1pUdOgv7z1",
+    "createdAt": null,
+    "entryIds": [
+      "zpU6LSH8muIVRlaKzBBs",
+      "s7kNOLpV7jDWt1g4JMgE",
+      "DMDEUdmPp8Mxu3TahIU8"
+    ]
+  },
+  {
+    "id": "GgyKBR85ljfKOjjVxsrKyBu9Uz12",
+    "createdAt": null,
+    "entryIds": [
+      "vdehXgTYyN9G7bXIrxcq"
+    ]
+  },
+  {
+    "id": "Gsxx8mRILHcM5ljSq01e8sVT4u43",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "jjuroEWrFNmuaJr39BNh",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "H5Qy8GtvfuaufS2ivdEyQpiwvNP2",
+    "createdAt": "2023-01-30T10:37:43.399Z",
+    "entryKinds": {
+      "オフラインブルーグラスアワード": "Z2kTfP53OAu0mBEvCBOC"
+    }
+  },
+  {
+    "id": "I3T9p2w9tMcREtnHDtMOzDLNH4n1",
+    "createdAt": "2023-01-31T12:28:57.292Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "8WdUkk1tpBBMdXkQVKP4",
+      "ショートブルーグラスアワード": "FJ80qEthusSfDtf3kKyL",
+      "オフラインブルーグラスアワード": "Ul41ZrFYemqp85T7BPHb"
+    }
+  },
+  {
+    "id": "IWXLuDS5iHfccmshc0LS8nnQbov1",
+    "createdAt": "2020-12-20T04:04:51.442Z",
+    "entryKinds": {
+      "独創独自賞": "sGdp35Z2ptwkLh2oGUGd",
+      "演奏すごい賞": "sed69abRbIFr8w5X8bY3",
+      "ブルーグラス愛を感じる賞": "j6golAxQpsvYWSNdplsr",
+      "とにかく端的に好き": "dNxTUIHFUKweBpOfWblH",
+      "音声技術賞": "LEYd0aUMCgZXboSQ0IeF",
+      "心にしみた賞": "KcauPkBqaeexSDYqMSyy",
+      "動画編集技術賞": "IOGyTrcOkyVftwUkNW9L"
+    }
+  },
+  {
+    "id": "Ime6t8cbqcPBW1EUrVxWqglTpmI3",
+    "createdAt": "2021-12-30T03:36:27.972Z",
+    "entryKinds": {
+      "動画作品として好き": "9U4jBdwW7V66iqIhxCQk",
+      "音楽作品として好き": "O4uFGgf5oWP2XvT5AgE4",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "心にしみた": "svmOCuzUYnMgl2hBykTn",
+      "ブルーグラス愛を感じた": "4kRBVUYYPO6UyLG2lWS3",
+      "個人作品賞": "8uGZK0Vg3woSrjbzUc0W",
+      "独創独自的で好き": "t45KCg7aCSSpXAVRt2Pi"
+    }
+  },
+  {
+    "id": "IoHtqZb3kJdHm8SEUiBEAM7Uwqn2",
+    "createdAt": "2020-12-20T03:24:49.666Z",
+    "entryKinds": {
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH",
+      "ライブ動画賞": "IOGyTrcOkyVftwUkNW9L",
+      "心にしみた賞": "PltjutVS2TUS0NLkxiv6",
+      "音声技術賞": "sMQUG68mLn4MRytUzPa7",
+      "とにかく端的に好き": "IOGyTrcOkyVftwUkNW9L",
+      "ブルーグラス愛を感じる賞": "slTNZGTchaPKE3n69UPk",
+      "演奏すごい賞": "CZuB8zzuntOlN8VHenDn",
+      "独創独自賞": "2yTLiVZTDNmPwIZuHPCO"
+    }
+  },
+  {
+    "id": "JNMZGrfc4ZZDV5RBMghrZZuFW6m2",
+    "createdAt": null,
+    "entryIds": [
+      "gj485A0x7bjZzfG6ZL2b",
+      "s7kNOLpV7jDWt1g4JMgE",
+      "uDGLUffPSkpyIvTUVRy7"
+    ]
+  },
+  {
+    "id": "JstWm6PLVydQWDD4Ue5ft2xBR8g2",
+    "createdAt": "2020-12-20T05:22:29.278Z",
+    "entryKinds": {
+      "心にしみた賞": "OTcgLMwfT8LQMiVHN00Z"
+    }
+  },
+  {
+    "id": "KHgvm4OC2kdMlS6dK7FFontRIU82",
+    "createdAt": null,
+    "entryIds": [
+      "uxlT1vkozDGUrxUa2ZtJ",
+      "gj485A0x7bjZzfG6ZL2b",
+      "uDGLUffPSkpyIvTUVRy7"
+    ]
+  },
+  {
+    "id": "MoKKN5CWoaUnjHHrbXI11ImZozr2",
+    "createdAt": "2021-12-31T14:25:48.187Z",
+    "entryKinds": {
+      "ベストバンドと思う!": "HHVglTF1335QVkxvb7PF",
+      "音楽作品として好き": "svmOCuzUYnMgl2hBykTn",
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画作品として好き": "o7LuAlWNG7OUFaLyo0KE",
+      "独創独自的で好き": "4kRBVUYYPO6UyLG2lWS3",
+      "個人作品賞": "t45KCg7aCSSpXAVRt2Pi",
+      "ブルーグラス愛を感じた": "vPR1kqeB9wMxvLkF6go3",
+      "心にしみた": "8uGZK0Vg3woSrjbzUc0W"
+    }
+  },
+  {
+    "id": "NWSDndAP1LWKivv2ZiyPSuqhxr62",
+    "createdAt": null,
+    "entryIds": [
+      "gj485A0x7bjZzfG6ZL2b",
+      "uDGLUffPSkpyIvTUVRy7",
+      "zpU6LSH8muIVRlaKzBBs"
+    ]
+  },
+  {
+    "id": "NYUvcGTYwMaZE68ZpHM4xJTq6gz2",
+    "createdAt": null,
+    "entryIds": [
+      "rwIb2tlFOeC2PUWMtQg8",
+      "s7kNOLpV7jDWt1g4JMgE",
+      "aeZxzoBE2AakMFhmjSbH"
+    ]
+  },
+  {
+    "id": "Nl4xgbiXjDg8BXypGCrm0iDKPqE3",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh"
+    ]
+  },
+  {
+    "id": "O0Heo5l6xvMYPQWjKY7t7i9qzMm1",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "zpU6LSH8muIVRlaKzBBs",
+      "QbPSsjzAsadU2aQVRDNs"
+    ]
+  },
+  {
+    "id": "OC4b2X5MzTQhyM0aqvUnb5H5cYR2",
+    "createdAt": "2021-12-30T05:00:21.645Z",
+    "entryKinds": {
+      "ショートブルーグラスアワード": "FJ80qEthusSfDtf3kKyL",
+      "ブルーグラス愛を感じた": "HHVglTF1335QVkxvb7PF",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "音楽作品として好き": "9U4jBdwW7V66iqIhxCQk",
+      "とにかく好き": "svmOCuzUYnMgl2hBykTn",
+      "独創独自的で好き": "uOIUF9gFjPoEv5CcmP5P",
+      "心にしみた": "hdC7w49jP4VMXSHdX7WS",
+      "オフラインブルーグラスアワード": "Ul41ZrFYemqp85T7BPHb",
+      "オンラインブルーグラスアワード": "jQO6Vt7XMFzHo1Wa8aUy",
+      "動画作品として好き": "8uGZK0Vg3woSrjbzUc0W"
+    }
+  },
+  {
+    "id": "ODTEr90ZZ1a7K1eExsDLqffRJg93",
+    "createdAt": "2020-12-20T08:25:23.641Z",
+    "entryKinds": {
+      "ライブ動画賞": "xdcEC7sjT12ZiuimXUXg",
+      "動画編集技術賞": "xdcEC7sjT12ZiuimXUXg",
+      "独創独自賞": "xdcEC7sjT12ZiuimXUXg",
+      "演奏すごい賞": "xdcEC7sjT12ZiuimXUXg",
+      "ブルーグラス愛を感じる賞": "xdcEC7sjT12ZiuimXUXg",
+      "とにかく端的に好き": "xdcEC7sjT12ZiuimXUXg",
+      "音声技術賞": "xdcEC7sjT12ZiuimXUXg",
+      "心にしみた賞": "xdcEC7sjT12ZiuimXUXg"
+    }
+  },
+  {
+    "id": "OHWbdNZW7rPYuuGyce4L3vk2gQp1",
+    "createdAt": "2020-12-22T09:45:01.491Z",
+    "entryKinds": {
+      "心にしみた賞": "MMWYUDAtbNPw6Ugfmgpt"
+    }
+  },
+  {
+    "id": "OW2uRcRLG3PJL7eHBP14UZeesfB2",
+    "createdAt": "2020-12-20T01:56:19.888Z",
+    "entryKinds": {
+      "とにかく好き": "9U4jBdwW7V66iqIhxCQk",
+      "ベストバンドと思う!": "9U4jBdwW7V66iqIhxCQk",
+      "動画編集技術賞": "slTNZGTchaPKE3n69UPk",
+      "ブルーグラス愛を感じる賞": "s8AzIm0bsAsVlFaVsLyQ",
+      "独創独自的で好き": "4kRBVUYYPO6UyLG2lWS3",
+      "音声技術賞": "slTNZGTchaPKE3n69UPk",
+      "ブルーグラス愛を感じた": "HHVglTF1335QVkxvb7PF",
+      "独創独自賞": "UE3l1iIBSx04dO55O7Il",
+      "演奏すごい賞": "SDwkZJMmGa1HW1M1u9Rv",
+      "心にしみた賞": "KcauPkBqaeexSDYqMSyy",
+      "音楽作品として好き": "alZ4uc824NdPJWlse0yX",
+      "とにかく端的に好き": "KcauPkBqaeexSDYqMSyy",
+      "心にしみた": "fACvkZ3xDfLjCmcd6yP1",
+      "個人作品賞": "782GjIs7BFaEbtM4lsnM",
+      "動画作品として好き": "T5u178K0dw8wXdUTU5oU"
+    }
+  },
+  {
+    "id": "OYs0zztoiUhBHCKRn3OBKY9v26b2",
+    "createdAt": null,
+    "entryIds": [
+      "qYZMG26eovIhn9j217aV",
+      "rwIb2tlFOeC2PUWMtQg8",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "ObsSkRUVscbaTUetuH6b2y22flq1",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "rwIb2tlFOeC2PUWMtQg8",
+      "zpU6LSH8muIVRlaKzBBs"
+    ]
+  },
+  {
+    "id": "OlFvqIwaspbnGifDVCLYaXXFcdL2",
+    "createdAt": null,
+    "entryIds": [
+      "CAbhqYZI7P7SrPg9Zjqu",
+      "gj485A0x7bjZzfG6ZL2b",
+      "WBYj13bCP2p1Dm6A3OtT"
+    ]
+  },
+  {
+    "id": "OnwsRpdTjmb41q7Z7eouMB4j9TU2",
+    "createdAt": null,
+    "entryIds": [
+      "IRKkyVrzPYoAbzef7udY",
+      "2cwUikHBbvgXTsQXHh4O",
+      "Xim7WGtgz3kvlKyWR4Tm"
+    ]
+  },
+  {
+    "id": "P0vbrfKaXndAxOY50jBOkOHG9bm2",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "rwIb2tlFOeC2PUWMtQg8",
+      "qYZMG26eovIhn9j217aV"
+    ]
+  },
+  {
+    "id": "PBIXpw8a2eXWr3QuePQwyneV6se2",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "s7kNOLpV7jDWt1g4JMgE",
+      "nPyr6a1xpzrEoMOYiVVs"
+    ]
+  },
+  {
+    "id": "PLUVC2CiusdZ9iKrAh68sWTyNwf1",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "WBYj13bCP2p1Dm6A3OtT",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "Pst6lB1FBYeMKyamDASpIZm8fvQ2",
+    "createdAt": "2023-01-29T13:50:38.867Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "8WdUkk1tpBBMdXkQVKP4",
+      "ショートブルーグラスアワード": "2lITA6shVJoACheeNg80",
+      "オフラインブルーグラスアワード": "P5IceGASZKgcOd8ioEDj"
+    }
+  },
+  {
+    "id": "Pzew4S2X6Phuis7uFp6DS7PbwJW2",
+    "createdAt": "2021-12-31T04:35:15.752Z",
+    "entryKinds": {
+      "ブルーグラス愛を感じた": "HHVglTF1335QVkxvb7PF",
+      "動画作品として好き": "vPR1kqeB9wMxvLkF6go3",
+      "とにかく好き": "4kRBVUYYPO6UyLG2lWS3",
+      "音楽作品として好き": "9U4jBdwW7V66iqIhxCQk"
+    }
+  },
+  {
+    "id": "QOH6xrsF4JTNAw8ZvMMwiVphL3K2",
+    "createdAt": "2023-01-29T13:39:30.720Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "jQO6Vt7XMFzHo1Wa8aUy",
+      "ショートブルーグラスアワード": "twU9jyPyhmo5z27no4zx"
+    }
+  },
+  {
+    "id": "QlRlMz7XZsS5ZDa0sjJTAjvjKNq2",
+    "createdAt": "2020-12-20T03:57:02.423Z",
+    "entryKinds": {
+      "心にしみた賞": "OTcgLMwfT8LQMiVHN00Z",
+      "音声技術賞": "UE3l1iIBSx04dO55O7Il",
+      "ブルーグラス愛を感じる賞": "sMQUG68mLn4MRytUzPa7",
+      "とにかく端的に好き": "KcauPkBqaeexSDYqMSyy",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "動画編集技術賞": "1tHV4N2NIYdYXDHkBNnv",
+      "ライブ動画賞": "xdcEC7sjT12ZiuimXUXg"
+    }
+  },
+  {
+    "id": "RON360H2t9PrNPmsv4jr94agBHV2",
+    "createdAt": "2023-01-31T23:27:20.997Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "jQO6Vt7XMFzHo1Wa8aUy",
+      "ショートブルーグラスアワード": "9c2y6fz1txUVuuyjjDYt"
+    }
+  },
+  {
+    "id": "RW6uvGRlfAhjNUMrYNTOWjSJ5YB2",
+    "createdAt": null,
+    "entryIds": [
+      "s7kNOLpV7jDWt1g4JMgE",
+      "jjuroEWrFNmuaJr39BNh",
+      "uDGLUffPSkpyIvTUVRy7"
+    ]
+  },
+  {
+    "id": "RyKEbaR2fyZsSWaG92F6x2FUEy72",
+    "createdAt": "2020-12-20T05:46:03.813Z",
+    "entryKinds": {
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH",
+      "ライブ動画賞": "mardYDNcz6k3dsh1cBRh",
+      "音声技術賞": "1tHV4N2NIYdYXDHkBNnv",
+      "心にしみた賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "演奏すごい賞": "N7D2PFyi98GejHo01RGN",
+      "独創独自賞": "sMQUG68mLn4MRytUzPa7",
+      "とにかく端的に好き": "KcauPkBqaeexSDYqMSyy",
+      "ブルーグラス愛を感じる賞": "aj9EZuofNLKb1tZuHa30"
+    }
+  },
+  {
+    "id": "S88TysirdtOPZfShGc9tVzsE8xq2",
+    "createdAt": null,
+    "entryIds": [
+      "Xim7WGtgz3kvlKyWR4Tm",
+      "ipyRjzqecWtP3thsyixV",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "SDNZtDXaS6NhlhwUSaTsLS7yHnT2",
+    "createdAt": "2020-12-21T10:17:58.683Z",
+    "entryKinds": {
+      "独創独自賞": "bLTqDpa2L6iRzP02dnOO",
+      "演奏すごい賞": "CZuB8zzuntOlN8VHenDn",
+      "とにかく端的に好き": "IOGyTrcOkyVftwUkNW9L",
+      "ブルーグラス愛を感じる賞": "slTNZGTchaPKE3n69UPk",
+      "音声技術賞": "dNxTUIHFUKweBpOfWblH",
+      "心にしみた賞": "PltjutVS2TUS0NLkxiv6",
+      "動画編集技術賞": "sMQUG68mLn4MRytUzPa7"
+    }
+  },
+  {
+    "id": "STD5aNEimycQjEMPZAlN60kCqmv1",
+    "createdAt": "2020-12-21T06:54:32.022Z",
+    "entryKinds": {
+      "個人作品賞": "782GjIs7BFaEbtM4lsnM",
+      "とにかく端的に好き": "OTcgLMwfT8LQMiVHN00Z",
+      "心にしみた": "35swQJlOdgbl1NkZqOYz",
+      "オンラインブルーグラスアワード": "4RMWA1rONUjNgdKaRMVg",
+      "動画作品として好き": "BqIikJSykcxSvdESYFHL",
+      "心にしみた賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ブルーグラス愛を感じた": "4kRBVUYYPO6UyLG2lWS3",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "音楽作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ライブ動画賞": "IOGyTrcOkyVftwUkNW9L",
+      "独創独自的で好き": "BqIikJSykcxSvdESYFHL",
+      "音声技術賞": "dNxTUIHFUKweBpOfWblH",
+      "ブルーグラス愛を感じる賞": "s8AzIm0bsAsVlFaVsLyQ",
+      "オフラインブルーグラスアワード": "Ul41ZrFYemqp85T7BPHb",
+      "ショートブルーグラスアワード": "uXIXS6QPzpD4nJLWBppE",
+      "とにかく好き": "Re4ZMBXn8zybhRbusDPq",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画編集技術賞": "sMQUG68mLn4MRytUzPa7"
+    }
+  },
+  {
+    "id": "Sc1wMePwXGWH9nvaNPUb6cX1Jml1",
+    "createdAt": null,
+    "entryIds": [
+      "rwIb2tlFOeC2PUWMtQg8",
+      "uDGLUffPSkpyIvTUVRy7",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "T5AGGCwFzBgfUqXDzb0m26fhaDf1",
+    "createdAt": "2020-12-21T12:45:18.470Z",
+    "entryKinds": {
+      "独創独自賞": "MMWYUDAtbNPw6Ugfmgpt"
+    }
+  },
+  {
+    "id": "T8sbGQq3lDSx6z4AHJKDifcY4KJ2",
+    "createdAt": null,
+    "entryIds": [
+      "1HvlvZ1b0FcOtdCBhRVa",
+      "ipyRjzqecWtP3thsyixV",
+      "IRKkyVrzPYoAbzef7udY"
+    ]
+  },
+  {
+    "id": "TOSgYyOqf9RL8k9N25SKq0GnlhP2",
+    "createdAt": "2023-01-29T14:24:25.590Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "8WdUkk1tpBBMdXkQVKP4",
+      "ショートブルーグラスアワード": "2lITA6shVJoACheeNg80",
+      "オフラインブルーグラスアワード": "Z2kTfP53OAu0mBEvCBOC"
+    }
+  },
+  {
+    "id": "U75Y0lfjG2PzOLwYoaA9qlFzvzV2",
+    "createdAt": "2020-12-20T01:57:47.927Z",
+    "entryKinds": {
+      "心にしみた賞": "sed69abRbIFr8w5X8bY3",
+      "とにかく端的に好き": "KcauPkBqaeexSDYqMSyy",
+      "ブルーグラス愛を感じる賞": "slTNZGTchaPKE3n69UPk",
+      "演奏すごい賞": "CZuB8zzuntOlN8VHenDn",
+      "独創独自賞": "s8AzIm0bsAsVlFaVsLyQ"
+    }
+  },
+  {
+    "id": "UeYnwOuZkyQDshVkKZQObxj0Ekq1",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh"
+    ]
+  },
+  {
+    "id": "VhdXsoOm67OSWGgRgJ5Tnxwzstt1",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "IRKkyVrzPYoAbzef7udY",
+      "rwIb2tlFOeC2PUWMtQg8"
+    ]
+  },
+  {
+    "id": "WDxFzEckklQ9rEXOMmmWoxb1yQ52",
+    "createdAt": "2021-12-30T05:50:30.580Z",
+    "entryKinds": {
+      "ベストバンドと思う!": "HHVglTF1335QVkxvb7PF",
+      "音楽作品として好き": "9U4jBdwW7V66iqIhxCQk",
+      "とにかく好き": "vPR1kqeB9wMxvLkF6go3",
+      "動画作品として好き": "cajLYmAzjVQwaU7aQFlw",
+      "独創独自的で好き": "4kRBVUYYPO6UyLG2lWS3",
+      "個人作品賞": "8uGZK0Vg3woSrjbzUc0W",
+      "ブルーグラス愛を感じた": "hdC7w49jP4VMXSHdX7WS",
+      "心にしみた": "DwOU4dbdFZeKKBs3Rh3o"
+    }
+  },
+  {
+    "id": "WmAbG1uXfrTkeYqCdLDEukhCeuK2",
+    "createdAt": null,
+    "entryIds": [
+      "gj485A0x7bjZzfG6ZL2b",
+      "jjuroEWrFNmuaJr39BNh",
+      "rwIb2tlFOeC2PUWMtQg8"
+    ]
+  },
+  {
+    "id": "X0NRZ4hHwYVAadq6Y3MLRrogBap1",
+    "createdAt": "2023-01-29T05:00:14.511Z",
+    "entryKinds": {
+      "オフラインブルーグラスアワード": "Z2kTfP53OAu0mBEvCBOC"
+    }
+  },
+  {
+    "id": "X3m85Uzl29Pz4lIZsV4PT5VEpPG2",
+    "createdAt": "2023-01-30T11:52:34.633Z",
+    "entryKinds": {
+      "オフラインブルーグラスアワード": "Z2kTfP53OAu0mBEvCBOC"
+    }
+  },
+  {
+    "id": "ZLlgFu7CHzNLf7Y9mgYN16HXaWl1",
+    "createdAt": null,
+    "entryIds": [
+      "gj485A0x7bjZzfG6ZL2b",
+      "rwIb2tlFOeC2PUWMtQg8",
+      "hTZ79HtV8BYwSNsBlkpf"
+    ]
+  },
+  {
+    "id": "ZqPOzS8FCWQBSV9r91rwgJ35zCO2",
+    "createdAt": "2020-12-20T11:42:29.932Z",
+    "entryKinds": {
+      "独創独自的で好き": "O4uFGgf5oWP2XvT5AgE4",
+      "音声技術賞": "KcauPkBqaeexSDYqMSyy",
+      "ブルーグラス愛を感じる賞": "aj9EZuofNLKb1tZuHa30",
+      "オフラインブルーグラスアワード": "Ul41ZrFYemqp85T7BPHb",
+      "ショートブルーグラスアワード": "2lITA6shVJoACheeNg80",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH",
+      "とにかく好き": "Wq3zNPe4b4VaFAbamrEW",
+      "個人作品賞": "8uGZK0Vg3woSrjbzUc0W",
+      "とにかく端的に好き": "dNxTUIHFUKweBpOfWblH",
+      "オンラインブルーグラスアワード": "gLRbyuKUvJDKRXmsn3Pj",
+      "心にしみた": "svmOCuzUYnMgl2hBykTn",
+      "動画作品として好き": "t45KCg7aCSSpXAVRt2Pi",
+      "心にしみた賞": "N7D2PFyi98GejHo01RGN",
+      "ブルーグラス愛を感じた": "HHVglTF1335QVkxvb7PF",
+      "演奏すごい賞": "sGdp35Z2ptwkLh2oGUGd",
+      "独創独自賞": "sMQUG68mLn4MRytUzPa7",
+      "音楽作品として好き": "4kRBVUYYPO6UyLG2lWS3"
+    }
+  },
+  {
+    "id": "Zxe4MwcPWPgSWNjFcUC9y9LrrB23",
+    "createdAt": "2023-01-29T13:52:21.379Z",
+    "entryKinds": {
+      "オフラインブルーグラスアワード": "Z2kTfP53OAu0mBEvCBOC"
+    }
+  },
+  {
+    "id": "aTy6W2RkC2U08B9b49JtXDcNuSX2",
+    "createdAt": null,
+    "entryIds": [
+      "1HvlvZ1b0FcOtdCBhRVa",
+      "uDGLUffPSkpyIvTUVRy7",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "aVYrR2V4nuX1dTWRmWsNdTjw8f83",
+    "createdAt": "2020-12-22T12:52:12.486Z",
+    "entryKinds": {
+      "独創独自的で好き": "Wq3zNPe4b4VaFAbamrEW",
+      "音声技術賞": "sGdp35Z2ptwkLh2oGUGd",
+      "ブルーグラス愛を感じる賞": "sed69abRbIFr8w5X8bY3",
+      "オフラインブルーグラスアワード": "P5IceGASZKgcOd8ioEDj",
+      "ショートブルーグラスアワード": "FJ80qEthusSfDtf3kKyL",
+      "とにかく好き": "uOIUF9gFjPoEv5CcmP5P",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画編集技術賞": "bJHGuI5kZ9v7S83oc5KI",
+      "個人作品賞": "PqEK5LjNPZPyMJputeQ3",
+      "とにかく端的に好き": "MMWYUDAtbNPw6Ugfmgpt",
+      "心にしみた": "svmOCuzUYnMgl2hBykTn",
+      "オンラインブルーグラスアワード": "ZR4QzjmHlE5KUDHpNVdZ",
+      "動画作品として好き": "8uGZK0Vg3woSrjbzUc0W",
+      "心にしみた賞": "OTcgLMwfT8LQMiVHN00Z",
+      "ブルーグラス愛を感じた": "35swQJlOdgbl1NkZqOYz",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "音楽作品として好き": "cajLYmAzjVQwaU7aQFlw",
+      "ライブ動画賞": "j6golAxQpsvYWSNdplsr"
+    }
+  },
+  {
+    "id": "bZ1kfpoPDnOnkPueATxTZ6H5MB03",
+    "createdAt": "2020-12-20T07:44:07.894Z",
+    "entryKinds": {
+      "動画編集技術賞": "1tHV4N2NIYdYXDHkBNnv",
+      "とにかく端的に好き": "sMQUG68mLn4MRytUzPa7",
+      "ブルーグラス愛を感じる賞": "LEYd0aUMCgZXboSQ0IeF",
+      "オンラインブルーグラスアワード": "4RMWA1rONUjNgdKaRMVg",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "演奏すごい賞": "PltjutVS2TUS0NLkxiv6",
+      "心にしみた賞": "2yTLiVZTDNmPwIZuHPCO",
+      "音声技術賞": "MMWYUDAtbNPw6Ugfmgpt"
+    }
+  },
+  {
+    "id": "bdPdoggGxoST2LoV2AMq0Vlqght2",
+    "createdAt": "2020-12-20T13:25:18.858Z",
+    "entryKinds": {
+      "ブルーグラス愛を感じる賞": "PltjutVS2TUS0NLkxiv6",
+      "音声技術賞": "PltjutVS2TUS0NLkxiv6",
+      "独創独自的で好き": "BqIikJSykcxSvdESYFHL",
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "とにかく好き": "O4uFGgf5oWP2XvT5AgE4",
+      "心にしみた": "vPR1kqeB9wMxvLkF6go3",
+      "とにかく端的に好き": "2yTLiVZTDNmPwIZuHPCO",
+      "個人作品賞": "t45KCg7aCSSpXAVRt2Pi",
+      "動画作品として好き": "8uGZK0Vg3woSrjbzUc0W",
+      "演奏すごい賞": "IOGyTrcOkyVftwUkNW9L",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "ブルーグラス愛を感じた": "svmOCuzUYnMgl2hBykTn",
+      "心にしみた賞": "pVqfeRg8lbJQowz24pD2",
+      "音楽作品として好き": "PqEK5LjNPZPyMJputeQ3"
+    }
+  },
+  {
+    "id": "cB47yr2zDSda8YJvxwRh6FukiYz1",
+    "createdAt": "2023-01-30T14:14:25.301Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "jQO6Vt7XMFzHo1Wa8aUy",
+      "ショートブルーグラスアワード": "2lITA6shVJoACheeNg80"
+    }
+  },
+  {
+    "id": "cV1omhBnYlR3hOg47SxMwZ53qSp2",
+    "createdAt": null,
+    "entryIds": [
+      "s7kNOLpV7jDWt1g4JMgE",
+      "QbPSsjzAsadU2aQVRDNs",
+      "WBYj13bCP2p1Dm6A3OtT"
+    ]
+  },
+  {
+    "id": "cov0nWmIQZUTiWzyw7VfEGBrEWP2",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "s7kNOLpV7jDWt1g4JMgE",
+      "qYZMG26eovIhn9j217aV"
+    ]
+  },
+  {
+    "id": "d1boeUrPSUc2Xc8zf2Xs8uQk8JX2",
+    "createdAt": null,
+    "entryIds": [
+      "Xim7WGtgz3kvlKyWR4Tm",
+      "QbPSsjzAsadU2aQVRDNs",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "dGPPaADf8waLgDLiKzpPHe8v7WT2",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "uDGLUffPSkpyIvTUVRy7",
+      "nPyr6a1xpzrEoMOYiVVs"
+    ]
+  },
+  {
+    "id": "dXlws56utXYBrvIO4ACzciENiNj1",
+    "createdAt": null,
+    "entryIds": [
+      "IhcaTBwekXIluANHJo4B",
+      "960A88dcNfBYjlHJJMy0"
+    ]
+  },
+  {
+    "id": "eDjEvP4r5Pg2zQ3gA0FFNhEb8U63",
+    "createdAt": "2021-12-30T06:31:14.152Z",
+    "entryKinds": {
+      "動画作品として好き": "8uGZK0Vg3woSrjbzUc0W",
+      "オンラインブルーグラスアワード": "jQO6Vt7XMFzHo1Wa8aUy",
+      "心にしみた": "uOIUF9gFjPoEv5CcmP5P",
+      "オフラインブルーグラスアワード": "Ul41ZrFYemqp85T7BPHb",
+      "独創独自的で好き": "T5u178K0dw8wXdUTU5oU",
+      "個人作品賞": "782GjIs7BFaEbtM4lsnM",
+      "とにかく好き": "O4uFGgf5oWP2XvT5AgE4",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "音楽作品として好き": "svmOCuzUYnMgl2hBykTn",
+      "ブルーグラス愛を感じた": "9U4jBdwW7V66iqIhxCQk"
+    }
+  },
+  {
+    "id": "eIeKko4zqZglm7TMPmMRoneCOtm2",
+    "createdAt": "2020-12-20T09:11:38.975Z",
+    "entryKinds": {
+      "音楽作品として好き": "uOIUF9gFjPoEv5CcmP5P",
+      "ライブ動画賞": "j6golAxQpsvYWSNdplsr",
+      "心にしみた賞": "sGdp35Z2ptwkLh2oGUGd",
+      "独創独自賞": "SOlp4sz006CxeLNzlMfn",
+      "演奏すごい賞": "SDwkZJMmGa1HW1M1u9Rv",
+      "ブルーグラス愛を感じた": "4kRBVUYYPO6UyLG2lWS3",
+      "動画作品として好き": "t45KCg7aCSSpXAVRt2Pi",
+      "個人作品賞": "cajLYmAzjVQwaU7aQFlw",
+      "心にしみた": "Re4ZMBXn8zybhRbusDPq",
+      "オンラインブルーグラスアワード": "jQO6Vt7XMFzHo1Wa8aUy",
+      "とにかく端的に好き": "2yTLiVZTDNmPwIZuHPCO",
+      "とにかく好き": "BqIikJSykcxSvdESYFHL",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH",
+      "ショートブルーグラスアワード": "uXIXS6QPzpD4nJLWBppE",
+      "音声技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "独創独自的で好き": "Wq3zNPe4b4VaFAbamrEW",
+      "オフラインブルーグラスアワード": "Ul41ZrFYemqp85T7BPHb",
+      "ブルーグラス愛を感じる賞": "CZuB8zzuntOlN8VHenDn"
+    }
+  },
+  {
+    "id": "eNBFPLCcUnf0ZRzuXBAaHbpsh1o2",
+    "createdAt": "2023-01-29T10:49:55.506Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "jQO6Vt7XMFzHo1Wa8aUy",
+      "ショートブルーグラスアワード": "uXIXS6QPzpD4nJLWBppE"
+    }
+  },
+  {
+    "id": "eliiNArShsbFhPo1QpKz5tgpHCn2",
+    "createdAt": null,
+    "entryIds": [
+      "gj485A0x7bjZzfG6ZL2b",
+      "zpU6LSH8muIVRlaKzBBs",
+      "uDGLUffPSkpyIvTUVRy7"
+    ]
+  },
+  {
+    "id": "ewuOp5buyEP5WSoJJtc0eIaLNiq2",
+    "createdAt": null,
+    "entryIds": [
+      "s7kNOLpV7jDWt1g4JMgE",
+      "Xim7WGtgz3kvlKyWR4Tm",
+      "IRKkyVrzPYoAbzef7udY"
+    ]
+  },
+  {
+    "id": "exmsLd5KXMX35RWnxxIQTPD03kC3",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "rwIb2tlFOeC2PUWMtQg8",
+      "2cwUikHBbvgXTsQXHh4O"
+    ]
+  },
+  {
+    "id": "fNCNCttaTZWJLvLr9BuzWi7ZYT83",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "ipyRjzqecWtP3thsyixV",
+      "1HvlvZ1b0FcOtdCBhRVa"
+    ]
+  },
+  {
+    "id": "gGPQDpCP1lPkIK0r4EXHdlM8HrV2",
+    "createdAt": "2021-12-31T12:45:56.960Z",
+    "entryKinds": {
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW"
+    }
+  },
+  {
+    "id": "gKedbufYaYggfnmhMmZCYei8vcE2",
+    "createdAt": "2020-12-20T07:00:26.666Z",
+    "entryKinds": {
+      "動画編集技術賞": "1tHV4N2NIYdYXDHkBNnv",
+      "音声技術賞": "UE3l1iIBSx04dO55O7Il",
+      "心にしみた賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "演奏すごい賞": "bLTqDpa2L6iRzP02dnOO",
+      "ブルーグラス愛を感じる賞": "aj9EZuofNLKb1tZuHa30",
+      "とにかく端的に好き": "IOGyTrcOkyVftwUkNW9L"
+    }
+  },
+  {
+    "id": "gsChzQDoIzT3MJeBlYG5uR2ExuG2",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "s7kNOLpV7jDWt1g4JMgE",
+      "CAbhqYZI7P7SrPg9Zjqu"
+    ]
+  },
+  {
+    "id": "iCcVLlFtGvcaDBt78Og7LgYbKIv1",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "jjuroEWrFNmuaJr39BNh",
+      "CAbhqYZI7P7SrPg9Zjqu"
+    ]
+  },
+  {
+    "id": "iGe8QCaIskSjc5TeEnPyZFFI7w03",
+    "createdAt": null,
+    "entryIds": [
+      "aeZxzoBE2AakMFhmjSbH",
+      "jjuroEWrFNmuaJr39BNh",
+      "nPyr6a1xpzrEoMOYiVVs"
+    ]
+  },
+  {
+    "id": "ibpwkNB0ssRgAkc6v4UfpFVuTts1",
+    "createdAt": "2023-01-29T11:42:16.715Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "kXnMhFzCGMVwHQheTZFq",
+      "ショートブルーグラスアワード": "9c2y6fz1txUVuuyjjDYt",
+      "オフラインブルーグラスアワード": "Z2kTfP53OAu0mBEvCBOC"
+    }
+  },
+  {
+    "id": "jJPlXsvDGzTOhb8nmtm1GclonjQ2",
+    "createdAt": "2021-12-31T08:41:24.512Z",
+    "entryKinds": {
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW"
+    }
+  },
+  {
+    "id": "jj3mMQK3FrVpZxJw9tnWBk8XNOl2",
+    "createdAt": "2021-12-30T03:24:09.338Z",
+    "entryKinds": {
+      "個人作品賞": "PqEK5LjNPZPyMJputeQ3",
+      "独創独自的で好き": "4kRBVUYYPO6UyLG2lWS3",
+      "心にしみた": "DwOU4dbdFZeKKBs3Rh3o",
+      "ブルーグラス愛を感じた": "DwOU4dbdFZeKKBs3Rh3o",
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "音楽作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画作品として好き": "DwOU4dbdFZeKKBs3Rh3o"
+    }
+  },
+  {
+    "id": "kYeAndUFalMnXDGkiCpfKXisHzN2",
+    "createdAt": "2020-12-20T01:59:02.492Z",
+    "entryKinds": {
+      "動画編集技術賞": "1tHV4N2NIYdYXDHkBNnv",
+      "独創独自賞": "SOlp4sz006CxeLNzlMfn",
+      "演奏すごい賞": "xdcEC7sjT12ZiuimXUXg",
+      "ブルーグラス愛を感じる賞": "SE2hd8nSxiXvHhz84rVL",
+      "とにかく端的に好き": "dNxTUIHFUKweBpOfWblH",
+      "音声技術賞": "IOGyTrcOkyVftwUkNW9L",
+      "心にしみた賞": "4PX2FlBsmFzC6kDK6O6U"
+    }
+  },
+  {
+    "id": "kzyhFyKxiGgkZIeJW1d6ZTEajo33",
+    "createdAt": "2020-12-20T01:47:14.839Z",
+    "entryKinds": {
+      "独創独自賞": "bJHGuI5kZ9v7S83oc5KI",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "とにかく端的に好き": "dNxTUIHFUKweBpOfWblH",
+      "ブルーグラス愛を感じる賞": "s8AzIm0bsAsVlFaVsLyQ",
+      "音声技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "心にしみた賞": "pVqfeRg8lbJQowz24pD2",
+      "動画編集技術賞": "sMQUG68mLn4MRytUzPa7"
+    }
+  },
+  {
+    "id": "m0qMCSqbIJgJkfdgwdUbm4ZRcsf2",
+    "createdAt": null,
+    "entryIds": [
+      "Xim7WGtgz3kvlKyWR4Tm",
+      "CAbhqYZI7P7SrPg9Zjqu",
+      "IRKkyVrzPYoAbzef7udY"
+    ]
+  },
+  {
+    "id": "mB4De7qaFZRjO9ytAc8BZxYhYaA3",
+    "createdAt": null,
+    "entryIds": [
+      "tUUIbE56ywaQmlcoAtr9",
+      "adXryDV5Ba58KFCflEmn",
+      "jjuroEWrFNmuaJr39BNh"
+    ]
+  },
+  {
+    "id": "mbz14FtNTLfxIorXQPgfwu5Iqxl1",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "jjuroEWrFNmuaJr39BNh",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "meSK6o34ZJS94SFgQ6d61jWcWUf1",
+    "createdAt": "2020-12-22T12:50:50.515Z",
+    "entryKinds": {
+      "動画編集技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "とにかく好き": "9U4jBdwW7V66iqIhxCQk",
+      "心にしみた賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "演奏すごい賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "独創独自賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ブルーグラス愛を感じた": "o7LuAlWNG7OUFaLyo0KE",
+      "音声技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW",
+      "ブルーグラス愛を感じる賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "とにかく端的に好き": "MMWYUDAtbNPw6Ugfmgpt"
+    }
+  },
+  {
+    "id": "mfIagJDOPRWFnxPYobBikJckwSV2",
+    "createdAt": null,
+    "entryIds": [
+      "IRKkyVrzPYoAbzef7udY",
+      "uxlT1vkozDGUrxUa2ZtJ",
+      "qYZMG26eovIhn9j217aV"
+    ]
+  },
+  {
+    "id": "mqB29MKPUXVAxdkOC2zrIrIM9TG2",
+    "createdAt": "2021-12-30T03:01:19.141Z",
+    "entryKinds": {
+      "動画作品として好き": "O4uFGgf5oWP2XvT5AgE4",
+      "音楽作品として好き": "9U4jBdwW7V66iqIhxCQk",
+      "ベストバンドと思う!": "HHVglTF1335QVkxvb7PF",
+      "とにかく好き": "Re4ZMBXn8zybhRbusDPq",
+      "心にしみた": "DwOU4dbdFZeKKBs3Rh3o",
+      "ブルーグラス愛を感じた": "hdC7w49jP4VMXSHdX7WS",
+      "独創独自的で好き": "t45KCg7aCSSpXAVRt2Pi"
+    }
+  },
+  {
+    "id": "mxtWRtvtuehpy91AG6KuRPfM5Nz2",
+    "createdAt": null,
+    "entryIds": [
+      "IRKkyVrzPYoAbzef7udY",
+      "DMDEUdmPp8Mxu3TahIU8",
+      "2cwUikHBbvgXTsQXHh4O"
+    ]
+  },
+  {
+    "id": "n1HmxR3oi7ZKRpwy9QJGMMxIwO72",
+    "createdAt": "2020-12-20T03:51:46.239Z",
+    "entryKinds": {
+      "オフラインブルーグラスアワード": "P5IceGASZKgcOd8ioEDj",
+      "オンラインブルーグラスアワード": "4RMWA1rONUjNgdKaRMVg",
+      "とにかく端的に好き": "KcauPkBqaeexSDYqMSyy",
+      "ブルーグラス愛を感じる賞": "dNxTUIHFUKweBpOfWblH",
+      "音声技術賞": "PltjutVS2TUS0NLkxiv6",
+      "独創独自賞": "1tHV4N2NIYdYXDHkBNnv",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "ショートブルーグラスアワード": "2lITA6shVJoACheeNg80",
+      "心にしみた賞": "slTNZGTchaPKE3n69UPk",
+      "ライブ動画賞": "IOGyTrcOkyVftwUkNW9L",
+      "動画編集技術賞": "LEYd0aUMCgZXboSQ0IeF"
+    }
+  },
+  {
+    "id": "nWpDIIsZF3eMUBmnXHYKIZ9Fmy73",
+    "createdAt": "2023-01-29T12:40:13.282Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "knpmWzgEfVNGpNlC1j8y",
+      "ショートブルーグラスアワード": "uXIXS6QPzpD4nJLWBppE",
+      "オフラインブルーグラスアワード": "P5IceGASZKgcOd8ioEDj"
+    }
+  },
+  {
+    "id": "nWplWD9jeRd8Yxfuo3DNcbWdfGk2",
+    "createdAt": null,
+    "entryIds": [
+      "s7kNOLpV7jDWt1g4JMgE",
+      "uDGLUffPSkpyIvTUVRy7",
+      "IRKkyVrzPYoAbzef7udY"
+    ]
+  },
+  {
+    "id": "nY44S86DPCP8hH7RnxWxew2mQGx2",
+    "createdAt": null,
+    "entryIds": [
+      "gj485A0x7bjZzfG6ZL2b",
+      "rwIb2tlFOeC2PUWMtQg8",
+      "DMDEUdmPp8Mxu3TahIU8"
+    ]
+  },
+  {
+    "id": "o68Y7vWleRPI7MEWvX50bttoXzB3",
+    "createdAt": null,
+    "entryIds": [
+      "qYZMG26eovIhn9j217aV",
+      "vdehXgTYyN9G7bXIrxcq",
+      "Xim7WGtgz3kvlKyWR4Tm"
+    ]
+  },
+  {
+    "id": "o9gvmJyLq2WSrXU8oaDqZgpYMgr2",
+    "createdAt": "2020-12-20T06:43:02.199Z",
+    "entryKinds": {
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ベストバンドと思う!": "9U4jBdwW7V66iqIhxCQk",
+      "動画編集技術賞": "sMQUG68mLn4MRytUzPa7",
+      "音声技術賞": "1tHV4N2NIYdYXDHkBNnv",
+      "独創独自的で好き": "t45KCg7aCSSpXAVRt2Pi",
+      "ブルーグラス愛を感じる賞": "OTcgLMwfT8LQMiVHN00Z",
+      "音楽作品として好き": "O4uFGgf5oWP2XvT5AgE4",
+      "心にしみた賞": "dNxTUIHFUKweBpOfWblH",
+      "演奏すごい賞": "slTNZGTchaPKE3n69UPk",
+      "独創独自賞": "sMQUG68mLn4MRytUzPa7",
+      "ブルーグラス愛を感じた": "4kRBVUYYPO6UyLG2lWS3",
+      "動画作品として好き": "BqIikJSykcxSvdESYFHL",
+      "個人作品賞": "8uGZK0Vg3woSrjbzUc0W",
+      "心にしみた": "svmOCuzUYnMgl2hBykTn",
+      "とにかく端的に好き": "h5bp3jponsPdaDH9zu8p"
+    }
+  },
+  {
+    "id": "oSxxjArSGSd6TRNq6P5evsJeI7r1",
+    "createdAt": "2020-12-20T02:08:40.508Z",
+    "entryKinds": {
+      "ブルーグラス愛を感じる賞": "j6golAxQpsvYWSNdplsr",
+      "とにかく端的に好き": "IOGyTrcOkyVftwUkNW9L",
+      "独創独自賞": "1tHV4N2NIYdYXDHkBNnv",
+      "演奏すごい賞": "h5bp3jponsPdaDH9zu8p",
+      "心にしみた賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "音声技術賞": "sed69abRbIFr8w5X8bY3",
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH"
+    }
+  },
+  {
+    "id": "oWVNJ9NcnAVy1129v78w9EjHOd33",
+    "createdAt": null,
+    "entryIds": [
+      "Xim7WGtgz3kvlKyWR4Tm",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "p1mn1W6XjJSlKVqKPPziH18VV3L2",
+    "createdAt": "2021-12-30T02:55:56.163Z",
+    "entryKinds": {
+      "動画作品として好き": "9U4jBdwW7V66iqIhxCQk",
+      "ベストバンドと思う!": "9U4jBdwW7V66iqIhxCQk",
+      "音楽作品として好き": "9U4jBdwW7V66iqIhxCQk",
+      "とにかく好き": "9U4jBdwW7V66iqIhxCQk",
+      "心にしみた": "9U4jBdwW7V66iqIhxCQk",
+      "ブルーグラス愛を感じた": "9U4jBdwW7V66iqIhxCQk",
+      "独創独自的で好き": "9U4jBdwW7V66iqIhxCQk"
+    }
+  },
+  {
+    "id": "pEu4TYSIJNWOPlwSESmTrUxy7A53",
+    "createdAt": "2020-12-21T10:14:38.480Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "8WdUkk1tpBBMdXkQVKP4",
+      "ショートブルーグラスアワード": "FJ80qEthusSfDtf3kKyL",
+      "オフラインブルーグラスアワード": "Z2kTfP53OAu0mBEvCBOC",
+      "心にしみた賞": "PltjutVS2TUS0NLkxiv6"
+    }
+  },
+  {
+    "id": "pGZFVtaeO8YnT9Nv3Tp94eBT4zb2",
+    "createdAt": "2020-12-20T02:33:43.477Z",
+    "entryKinds": {
+      "ブルーグラス愛を感じる賞": "slTNZGTchaPKE3n69UPk",
+      "ライブ動画賞": "xdcEC7sjT12ZiuimXUXg",
+      "音声技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "動画編集技術賞": "MMWYUDAtbNPw6Ugfmgpt"
+    }
+  },
+  {
+    "id": "pwpm94jSPWM5bz6jaf8vX6DJ6TW2",
+    "createdAt": "2020-12-21T04:07:39.537Z",
+    "entryKinds": {
+      "心にしみた賞": "sed69abRbIFr8w5X8bY3",
+      "ブルーグラス愛を感じた": "9U4jBdwW7V66iqIhxCQk",
+      "独創独自賞": "IOGyTrcOkyVftwUkNW9L",
+      "とにかく好き": "svmOCuzUYnMgl2hBykTn",
+      "ベストバンドと思う!": "o7LuAlWNG7OUFaLyo0KE",
+      "音楽作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画編集技術賞": "sMQUG68mLn4MRytUzPa7",
+      "独創独自的で好き": "fACvkZ3xDfLjCmcd6yP1",
+      "とにかく端的に好き": "OTcgLMwfT8LQMiVHN00Z",
+      "ブルーグラス愛を感じる賞": "j6golAxQpsvYWSNdplsr",
+      "心にしみた": "o7LuAlWNG7OUFaLyo0KE",
+      "動画作品として好き": "4kRBVUYYPO6UyLG2lWS3"
+    }
+  },
+  {
+    "id": "q6dRrnz2cbSZZtsvTnsh5pB0omX2",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "ipyRjzqecWtP3thsyixV",
+      "uDGLUffPSkpyIvTUVRy7"
+    ]
+  },
+  {
+    "id": "qK7sSbrGqoP4TAV4xftGGTyAfOo2",
+    "createdAt": "2021-12-31T03:31:22.661Z",
+    "entryKinds": {
+      "動画作品として好き": "4kRBVUYYPO6UyLG2lWS3",
+      "とにかく好き": "vPR1kqeB9wMxvLkF6go3",
+      "ベストバンドと思う!": "9U4jBdwW7V66iqIhxCQk",
+      "音楽作品として好き": "O4uFGgf5oWP2XvT5AgE4",
+      "ブルーグラス愛を感じた": "AfGw6sgQDxVbUACgWtCB",
+      "心にしみた": "svmOCuzUYnMgl2hBykTn",
+      "独創独自的で好き": "BqIikJSykcxSvdESYFHL"
+    }
+  },
+  {
+    "id": "qOtsADW9daadkOub2XWzTWYkx7Y2",
+    "createdAt": null,
+    "entryIds": [
+      "DMDEUdmPp8Mxu3TahIU8",
+      "IRKkyVrzPYoAbzef7udY",
+      "NYmMaq4dSroiGMhLfNcU"
+    ]
+  },
+  {
+    "id": "qX49BajiqgOyL9RRfaiGlS17qi23",
+    "createdAt": "2020-12-20T02:44:59.896Z",
+    "entryKinds": {
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH",
+      "とにかく端的に好き": "MMWYUDAtbNPw6Ugfmgpt",
+      "独創独自賞": "sMQUG68mLn4MRytUzPa7",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy"
+    }
+  },
+  {
+    "id": "rETQ1gDtVYXYkbSh3KaROPok0mI2",
+    "createdAt": "2021-12-30T03:15:59.368Z",
+    "entryKinds": {
+      "独創独自的で好き": "Wq3zNPe4b4VaFAbamrEW",
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW",
+      "心にしみた": "DwOU4dbdFZeKKBs3Rh3o",
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "音楽作品として好き": "BqIikJSykcxSvdESYFHL"
+    }
+  },
+  {
+    "id": "rLTOhKHVKjZ8LOguiWEVzCzL1Jr2",
+    "createdAt": "2021-12-31T09:15:20.788Z",
+    "entryKinds": {
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "音楽作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画作品として好き": "9U4jBdwW7V66iqIhxCQk",
+      "独創独自的で好き": "4kRBVUYYPO6UyLG2lWS3",
+      "ブルーグラス愛を感じた": "o7LuAlWNG7OUFaLyo0KE",
+      "心にしみた": "DwOU4dbdFZeKKBs3Rh3o"
+    }
+  },
+  {
+    "id": "rjXGchJDKASz6iwBNhg5CUjSz7d2",
+    "createdAt": "2021-12-31T13:43:01.788Z",
+    "entryKinds": {
+      "ブルーグラス愛を感じた": "o7LuAlWNG7OUFaLyo0KE",
+      "心にしみた": "DwOU4dbdFZeKKBs3Rh3o",
+      "独創独自的で好き": "9U4jBdwW7V66iqIhxCQk",
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW",
+      "動画作品として好き": "PqEK5LjNPZPyMJputeQ3",
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "音楽作品として好き": "Wq3zNPe4b4VaFAbamrEW"
+    }
+  },
+  {
+    "id": "s3L9uytpgkV2yfEqgb3evLANgEf1",
+    "createdAt": "2020-12-20T01:48:01.740Z",
+    "entryKinds": {
+      "音楽作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "演奏すごい賞": "CZuB8zzuntOlN8VHenDn",
+      "独創独自賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ブルーグラス愛を感じた": "t45KCg7aCSSpXAVRt2Pi",
+      "心にしみた賞": "KcauPkBqaeexSDYqMSyy",
+      "動画作品として好き": "4kRBVUYYPO6UyLG2lWS3",
+      "心にしみた": "svmOCuzUYnMgl2hBykTn",
+      "とにかく端的に好き": "OTcgLMwfT8LQMiVHN00Z",
+      "個人作品賞": "PqEK5LjNPZPyMJputeQ3",
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH",
+      "ベストバンドと思う!": "9U4jBdwW7V66iqIhxCQk",
+      "とにかく好き": "35swQJlOdgbl1NkZqOYz",
+      "ブルーグラス愛を感じる賞": "2yTLiVZTDNmPwIZuHPCO",
+      "音声技術賞": "SDwkZJMmGa1HW1M1u9Rv",
+      "独創独自的で好き": "Wq3zNPe4b4VaFAbamrEW"
+    }
+  },
+  {
+    "id": "sAIuX1bkfYNKu21EuT6sZemPAzH2",
+    "createdAt": null,
+    "entryIds": [
+      "s7kNOLpV7jDWt1g4JMgE",
+      "QbPSsjzAsadU2aQVRDNs",
+      "uxlT1vkozDGUrxUa2ZtJ"
+    ]
+  },
+  {
+    "id": "sJj1QaB7vTY7hAn29tAmRo7nyFL2",
+    "createdAt": null,
+    "entryIds": [
+      "zpU6LSH8muIVRlaKzBBs",
+      "jjuroEWrFNmuaJr39BNh",
+      "hTZ79HtV8BYwSNsBlkpf"
+    ]
+  },
+  {
+    "id": "sVEqTB2omqejR0ODur1BdQBbxgF2",
+    "createdAt": "2021-12-30T22:36:35.719Z",
+    "entryKinds": {
+      "動画作品として好き": "9U4jBdwW7V66iqIhxCQk",
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ベストバンドと思う!": "9U4jBdwW7V66iqIhxCQk",
+      "音楽作品として好き": "svmOCuzUYnMgl2hBykTn",
+      "ブルーグラス愛を感じた": "HHVglTF1335QVkxvb7PF",
+      "心にしみた": "ww4X3UcdTxybjW0a09yo",
+      "独創独自的で好き": "cajLYmAzjVQwaU7aQFlw",
+      "個人作品賞": "PqEK5LjNPZPyMJputeQ3"
+    }
+  },
+  {
+    "id": "t24DC6w24SQOmVSA88XQCc22xa22",
+    "createdAt": "2020-12-22T10:23:02.631Z",
+    "entryKinds": {
+      "心にしみた賞": "pVqfeRg8lbJQowz24pD2",
+      "音声技術賞": "pVqfeRg8lbJQowz24pD2",
+      "ブルーグラス愛を感じる賞": "OTcgLMwfT8LQMiVHN00Z",
+      "とにかく端的に好き": "KcauPkBqaeexSDYqMSyy",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH"
+    }
+  },
+  {
+    "id": "tiZj5qnjv6Pr3aFDFlnlRpWN4IZ2",
+    "createdAt": "2020-12-20T12:05:45.109Z",
+    "entryKinds": {
+      "心にしみた賞": "sed69abRbIFr8w5X8bY3"
+    }
+  },
+  {
+    "id": "tqhB4NvPcUOGLcf6BBB20M3vRFA2",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "uDGLUffPSkpyIvTUVRy7"
+    ]
+  },
+  {
+    "id": "tqnXaGWW7SQLb6XAO4519HDTcCT2",
+    "createdAt": null,
+    "entryIds": [
+      "s7kNOLpV7jDWt1g4JMgE",
+      "zpU6LSH8muIVRlaKzBBs",
+      "IRKkyVrzPYoAbzef7udY"
+    ]
+  },
+  {
+    "id": "u43wkugDnXU0FSlXXST0unlTOik2",
+    "createdAt": "2021-12-31T10:11:32.389Z",
+    "entryKinds": {
+      "心にしみた": "Re4ZMBXn8zybhRbusDPq",
+      "とにかく好き": "O4uFGgf5oWP2XvT5AgE4",
+      "音楽作品として好き": "Wq3zNPe4b4VaFAbamrEW",
+      "独創独自的で好き": "BqIikJSykcxSvdESYFHL"
+    }
+  },
+  {
+    "id": "uOe5aZPaHDP4VOM3VDObGFJFjeN2",
+    "createdAt": "2020-12-21T00:38:46.008Z",
+    "entryKinds": {
+      "心にしみた賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ブルーグラス愛を感じた": "4kRBVUYYPO6UyLG2lWS3",
+      "演奏すごい賞": "s8AzIm0bsAsVlFaVsLyQ",
+      "独創独自賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "音楽作品として好き": "8uGZK0Vg3woSrjbzUc0W",
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW",
+      "とにかく端的に好き": "dNxTUIHFUKweBpOfWblH",
+      "動画作品として好き": "vPR1kqeB9wMxvLkF6go3",
+      "動画編集技術賞": "dNxTUIHFUKweBpOfWblH",
+      "ベストバンドと思う!": "9U4jBdwW7V66iqIhxCQk",
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "音声技術賞": "sMQUG68mLn4MRytUzPa7",
+      "ブルーグラス愛を感じる賞": "CZuB8zzuntOlN8VHenDn"
+    }
+  },
+  {
+    "id": "ucFN2OaAoVWhinJQ2J5LfT7qy7l1",
+    "createdAt": "2023-01-29T03:17:33.042Z",
+    "entryKinds": {
+      "オフラインブルーグラスアワード": "Sd1rXqWwV2pLiAotf15r"
+    }
+  },
+  {
+    "id": "v2GMp3er4JZjZXgTQqe9BEJZYga2",
+    "createdAt": "2020-12-20T01:56:26.440Z",
+    "entryKinds": {
+      "心にしみた賞": "s8AzIm0bsAsVlFaVsLyQ",
+      "音声技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ブルーグラス愛を感じる賞": "CZuB8zzuntOlN8VHenDn",
+      "とにかく端的に好き": "sMQUG68mLn4MRytUzPa7",
+      "独創独自賞": "dNxTUIHFUKweBpOfWblH",
+      "演奏すごい賞": "sGdp35Z2ptwkLh2oGUGd",
+      "動画編集技術賞": "bJHGuI5kZ9v7S83oc5KI",
+      "ライブ動画賞": "IOGyTrcOkyVftwUkNW9L"
+    }
+  },
+  {
+    "id": "v2Ve1mrwtbexRBg5dI82yhbyJIK2",
+    "createdAt": null,
+    "entryIds": [
+      "rwIb2tlFOeC2PUWMtQg8",
+      "qYZMG26eovIhn9j217aV",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "v7RIGlLJagglGPzOmIg1359hBEp2",
+    "createdAt": null,
+    "entryIds": [
+      "jjuroEWrFNmuaJr39BNh",
+      "qYZMG26eovIhn9j217aV",
+      "6w0dm06G3mFV53flK7xo"
+    ]
+  },
+  {
+    "id": "vupipM8NDNf86oNiK3Gtd6q9u1H3",
+    "createdAt": null,
+    "entryIds": [
+      "6w0dm06G3mFV53flK7xo",
+      "jSyhnowRfbtQWx5F70Gh",
+      "jjuroEWrFNmuaJr39BNh"
+    ]
+  },
+  {
+    "id": "w0tSyuSBccOHLjI6gTZ0UcRoDq23",
+    "createdAt": null,
+    "entryIds": [
+      "zpU6LSH8muIVRlaKzBBs",
+      "uDGLUffPSkpyIvTUVRy7",
+      "s7kNOLpV7jDWt1g4JMgE"
+    ]
+  },
+  {
+    "id": "wDENg8zWTwRdE07aBy0DyCdA1hP2",
+    "createdAt": null,
+    "entryIds": [
+      "uDGLUffPSkpyIvTUVRy7",
+      "qYZMG26eovIhn9j217aV",
+      "DMDEUdmPp8Mxu3TahIU8"
+    ]
+  },
+  {
+    "id": "wFomU53rp2MtPj6S1yRB5nIlApf2",
+    "createdAt": null,
+    "entryIds": [
+      "1HvlvZ1b0FcOtdCBhRVa",
+      "uDGLUffPSkpyIvTUVRy7",
+      "NYmMaq4dSroiGMhLfNcU"
+    ]
+  },
+  {
+    "id": "wLLJHcqbsycPCwHR34ukGfd9Otj2",
+    "createdAt": null,
+    "entryIds": [
+      "gj485A0x7bjZzfG6ZL2b",
+      "rwIb2tlFOeC2PUWMtQg8",
+      "zpU6LSH8muIVRlaKzBBs"
+    ]
+  },
+  {
+    "id": "wUq7SsxPHFgsiHdoaS77xS7WJlI3",
+    "createdAt": "2020-12-20T14:49:03.341Z",
+    "entryKinds": {
+      "ブルーグラス愛を感じる賞": "N7D2PFyi98GejHo01RGN",
+      "演奏すごい賞": "s8AzIm0bsAsVlFaVsLyQ"
+    }
+  },
+  {
+    "id": "wmS8q2ZzTAOmWEB48cECmMZKDdz1",
+    "createdAt": null,
+    "entryIds": [
+      "ipyRjzqecWtP3thsyixV",
+      "1HvlvZ1b0FcOtdCBhRVa",
+      "qYZMG26eovIhn9j217aV"
+    ]
+  },
+  {
+    "id": "xcrAMfCqg4fwZGUgaa1PkKGbfjX2",
+    "createdAt": "2020-12-20T01:47:14.378Z",
+    "entryKinds": {
+      "心にしみた賞": "OTcgLMwfT8LQMiVHN00Z",
+      "音声技術賞": "OTcgLMwfT8LQMiVHN00Z",
+      "とにかく端的に好き": "h5bp3jponsPdaDH9zu8p",
+      "ブルーグラス愛を感じる賞": "j6golAxQpsvYWSNdplsr",
+      "演奏すごい賞": "KcauPkBqaeexSDYqMSyy",
+      "独創独自賞": "sMQUG68mLn4MRytUzPa7",
+      "動画編集技術賞": "OTcgLMwfT8LQMiVHN00Z"
+    }
+  },
+  {
+    "id": "xqqKWnmrIMbuX3Q6xOFyB19hs422",
+    "createdAt": "2021-12-30T03:08:41.646Z",
+    "entryKinds": {
+      "ブルーグラス愛を感じた": "HHVglTF1335QVkxvb7PF",
+      "ショートブルーグラスアワード": "9c2y6fz1txUVuuyjjDYt",
+      "音楽作品として好き": "Wq3zNPe4b4VaFAbamrEW",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "とにかく好き": "fACvkZ3xDfLjCmcd6yP1",
+      "独創独自的で好き": "4kRBVUYYPO6UyLG2lWS3",
+      "個人作品賞": "cajLYmAzjVQwaU7aQFlw",
+      "オンラインブルーグラスアワード": "bd4isAFeOG1KpzKFUDgK",
+      "心にしみた": "svmOCuzUYnMgl2hBykTn",
+      "動画作品として好き": "BqIikJSykcxSvdESYFHL"
+    }
+  },
+  {
+    "id": "y25ss68qyfhTRi3K64PZnhzo7A12",
+    "createdAt": null,
+    "entryIds": [
+      "qYZMG26eovIhn9j217aV",
+      "vdehXgTYyN9G7bXIrxcq"
+    ]
+  },
+  {
+    "id": "yEOgn8onR6XJZtUwftt7wNzKUPS2",
+    "createdAt": "2021-12-30T03:27:52.036Z",
+    "entryKinds": {
+      "動画作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "とにかく好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "音楽作品として好き": "DwOU4dbdFZeKKBs3Rh3o",
+      "心にしみた": "DwOU4dbdFZeKKBs3Rh3o",
+      "ブルーグラス愛を感じた": "DwOU4dbdFZeKKBs3Rh3o",
+      "個人作品賞": "PqEK5LjNPZPyMJputeQ3",
+      "独創独自的で好き": "4kRBVUYYPO6UyLG2lWS3"
+    }
+  },
+  {
+    "id": "yaj0bgmH7xbTqwrhhDB1wF0WT4s1",
+    "createdAt": "2023-01-31T06:57:59.723Z",
+    "entryKinds": {
+      "オンラインブルーグラスアワード": "knpmWzgEfVNGpNlC1j8y",
+      "ショートブルーグラスアワード": "uXIXS6QPzpD4nJLWBppE",
+      "オフラインブルーグラスアワード": "P5IceGASZKgcOd8ioEDj"
+    }
+  },
+  {
+    "id": "yvNS31UjQbUHbbtRJSEIEo8rZrB2",
+    "createdAt": null,
+    "entryIds": [
+      "rwIb2tlFOeC2PUWMtQg8",
+      "s7kNOLpV7jDWt1g4JMgE",
+      "gj485A0x7bjZzfG6ZL2b"
+    ]
+  },
+  {
+    "id": "z6AcJhu7djOZLh3BPEeAnnbXTHD2",
+    "createdAt": "2020-12-20T09:40:57.470Z",
+    "entryKinds": {
+      "動画編集技術賞": "sMQUG68mLn4MRytUzPa7",
+      "演奏すごい賞": "PltjutVS2TUS0NLkxiv6",
+      "独創独自賞": "b4CeAZa34JgSnIWOHM5t",
+      "とにかく端的に好き": "OTcgLMwfT8LQMiVHN00Z",
+      "ブルーグラス愛を感じる賞": "h5bp3jponsPdaDH9zu8p",
+      "音声技術賞": "dNxTUIHFUKweBpOfWblH",
+      "心にしみた賞": "2yTLiVZTDNmPwIZuHPCO"
+    }
+  },
+  {
+    "id": "zDeVF3qurASjbQtX0WVx9VO4qQS2",
+    "createdAt": "2020-12-20T03:02:41.032Z",
+    "entryKinds": {
+      "とにかく好き": "Wq3zNPe4b4VaFAbamrEW",
+      "ベストバンドと思う!": "DwOU4dbdFZeKKBs3Rh3o",
+      "動画編集技術賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ブルーグラス愛を感じる賞": "PltjutVS2TUS0NLkxiv6",
+      "音声技術賞": "UE3l1iIBSx04dO55O7Il",
+      "独創独自的で好き": "Wq3zNPe4b4VaFAbamrEW",
+      "演奏すごい賞": "PltjutVS2TUS0NLkxiv6",
+      "独創独自賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ブルーグラス愛を感じた": "35swQJlOdgbl1NkZqOYz",
+      "心にしみた賞": "MMWYUDAtbNPw6Ugfmgpt",
+      "ライブ動画賞": "xdcEC7sjT12ZiuimXUXg",
+      "音楽作品として好き": "Wq3zNPe4b4VaFAbamrEW",
+      "心にしみた": "Wq3zNPe4b4VaFAbamrEW",
+      "とにかく端的に好き": "MMWYUDAtbNPw6Ugfmgpt",
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW",
+      "動画作品として好き": "o7LuAlWNG7OUFaLyo0KE"
+    }
+  },
+  {
+    "id": "zSG0ZgpqKsZ1HwT3k3u3ysL53Ou1",
+    "createdAt": null,
+    "entryIds": [
+      "Xim7WGtgz3kvlKyWR4Tm"
+    ]
+  },
+  {
+    "id": "zYyduZzxNJcEZMDo3BsR5FVG44C3",
+    "createdAt": "2021-12-31T09:44:03.047Z",
+    "entryKinds": {
+      "心にしみた": "9U4jBdwW7V66iqIhxCQk",
+      "ブルーグラス愛を感じた": "hdC7w49jP4VMXSHdX7WS",
+      "個人作品賞": "Wq3zNPe4b4VaFAbamrEW",
+      "独創独自的で好き": "BqIikJSykcxSvdESYFHL",
+      "動画作品として好き": "4kRBVUYYPO6UyLG2lWS3",
+      "とにかく好き": "4kRBVUYYPO6UyLG2lWS3",
+      "音楽作品として好き": "Wq3zNPe4b4VaFAbamrEW"
+    }
+  },
+  {
+    "id": "zujZ7cNgy5QhwhcfW2znbgQaXzU2",
+    "createdAt": null,
+    "entryIds": [
+      "uxlT1vkozDGUrxUa2ZtJ",
+      "jjuroEWrFNmuaJr39BNh",
+      "gj485A0x7bjZzfG6ZL2b"
+    ]
+  }
+]


### PR DESCRIPTION
## 概要

#269 旧システムのFirestore `entries` / `votes` を、公開同意フラグを尊重した静的データ(JSON)に変換しました。

## 実装

- `scripts/export-legacy.mjs`: 旧Firebaseプロジェクト `bluemoon-82c0b` のFirestore REST API(公開読み取り可・認証不要)からデータを取得し変換
  - 同意ルール: `publishAgree === true` または同意チェックボックス導入前のVol.1(2020春)エントリー
  - `publishAgree === false` は明示的不同意のため除外(6件)
  - **個人情報(email / userId)は除去**
  - votesの2形式(Vol.1: entryIds配列 / Vol.2+: entryKinds賞別マップ)を正規化
- `src/data/legacy/`:
  - `events.json`: 4イベント(Vol.1〜4)のメタ情報
  - `entries.json`: 115件の同意済みエントリー
  - `votes.json`: 168件の投票(正規化済み)
  - `results.json`: イベント×エントリー別の得票集計(部門別+合計)
  - `summary.json`: エクスポートサマリ

## データ内容

| イベント | 年 | エントリー(同意済み) |
|---|---|---|
| Vol.1 オンラインフェス | 2020春 | 31 |
| Vol.2 | 2020年11月 | 30 |
| Vol.3 | 2021年11月 | 28 |
| Vol.4 | 2022年12月 | 26 |

## 検証

- 取得数: entries 121 → 同意済み115 / votes 168
- `npm run check`: 0 errors / `npm run build`: 成功
- エクスポート後のJSONにemail/userIdが含まれないことを確認
- スクリプトは再実行可能(`node scripts/export-legacy.mjs`)