### PR TITLE
Cloudflare Web Analyticsを有効化 (#107)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,8 @@ const { title } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <title>{title}</title>
+    <!-- Cloudflare Web Analytics -->
+    <script type="module" src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "54a7f9bfad8e4ae7b9545621d0d4409a"}'></script>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
## 概要

#107 analytics 有効化。旧Firebase Analyticsの代替として、Cloudflare Web Analytics(クッキー不要・同意バナー不要)を導入します。

## 変更

- `src/layouts/BaseLayout.astro` のheadにビーコンを追加(全ページに適用)

## 検証

- `npm run check`: 0 errors / `npm run build`: 成功
- 生成HTMLに data-cf-beacon が含まれることを確認
- マージ後: 本番HTMLのビーコン確認 → Cloudflareダッシュボードで計測開始を確認